### PR TITLE
LUCY-279 Obj method removal

### DIFF
--- a/c/src/Lucy/Index/Inverter.c
+++ b/c/src/Lucy/Index/Inverter.c
@@ -92,27 +92,23 @@ Inverter_Invert_Doc_IMP(Inverter *self, Doc *doc) {
                     break;
                 }
             case FType_INT32: {
-                    int32_t int_val = (int32_t)Obj_To_I64(obj);
                     Integer32* value = (Integer32*)inventry_ivars->value;
-                    Int32_Set_Value(value, int_val);
+                    Int32_Mimic(value, obj);
                     break;
                 }
             case FType_INT64: {
-                    int64_t int_val = Obj_To_I64(obj);
                     Integer64* value = (Integer64*)inventry_ivars->value;
-                    Int64_Set_Value(value, int_val);
+                    Int64_Mimic(value, obj);
                     break;
                 }
             case FType_FLOAT32: {
-                    float float_val = (float)Obj_To_F64(obj);
                     Float32* value = (Float32*)inventry_ivars->value;
-                    Float32_Set_Value(value, float_val);
+                    Float32_Mimic(value, obj);
                     break;
                 }
             case FType_FLOAT64: {
-                    double float_val = Obj_To_F64(obj);
                     Float64* value = (Float64*)inventry_ivars->value;
-                    Float64_Set_Value(value, float_val);
+                    Float64_Mimic(value, obj);
                     break;
                 }
             default:

--- a/core/Lucy/Analysis/Normalizer.c
+++ b/core/Lucy/Analysis/Normalizer.c
@@ -22,6 +22,7 @@
 #include "Lucy/Analysis/Normalizer.h"
 #include "Lucy/Analysis/Token.h"
 #include "Lucy/Analysis/Inversion.h"
+#include "Lucy/Util/Json.h"
 
 #include "utf8proc.h"
 
@@ -154,9 +155,9 @@ Normalizer_Load_IMP(Normalizer *self, Obj *dump) {
     Obj *obj = Hash_Fetch_Utf8(source, "normalization_form", 18);
     String *form = (String*)CERTIFY(obj, STRING);
     obj = Hash_Fetch_Utf8(source, "case_fold", 9);
-    bool case_fold = Obj_To_Bool(CERTIFY(obj, OBJ));
+    bool case_fold = Json_obj_to_bool(CERTIFY(obj, OBJ));
     obj = Hash_Fetch_Utf8(source, "strip_accents", 13);
-    bool strip_accents = Obj_To_Bool(CERTIFY(obj, OBJ));
+    bool strip_accents = Json_obj_to_bool(CERTIFY(obj, OBJ));
 
     return Normalizer_init(loaded, form, case_fold, strip_accents);
 }

--- a/core/Lucy/Document/HitDoc.c
+++ b/core/Lucy/Document/HitDoc.c
@@ -20,6 +20,7 @@
 #include "Lucy/Document/HitDoc.h"
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Json.h"
 
 HitDoc*
 HitDoc_new(void *fields, int32_t doc_id, float score) {
@@ -82,7 +83,7 @@ HitDoc_Load_IMP(HitDoc *self, Obj *dump) {
     HitDoc *loaded = super_load(self, dump);
     HitDocIVARS *const loaded_ivars = HitDoc_IVARS(loaded);
     Obj *score = CERTIFY(Hash_Fetch_Utf8(source, "score", 5), OBJ);
-    loaded_ivars->score = (float)Obj_To_F64(score);
+    loaded_ivars->score = (float)Json_obj_to_f64(score);
     return loaded;
 }
 

--- a/core/Lucy/Index/DeletionsReader.c
+++ b/core/Lucy/Index/DeletionsReader.c
@@ -30,6 +30,7 @@
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Util/IndexFileNames.h"
+#include "Lucy/Util/Json.h"
 
 DeletionsReader*
 DelReader_init(DeletionsReader *self, Schema *schema, Folder *folder,
@@ -177,7 +178,7 @@ DefDelReader_Read_Deletions_IMP(DefaultDeletionsReader *self) {
                 Obj *count = (Obj*)CERTIFY(
                                  Hash_Fetch_Utf8(seg_files_data, "count", 5),
                                  OBJ);
-                del_count = (int32_t)Obj_To_I64(count);
+                del_count = (int32_t)Json_obj_to_i64(count);
                 del_file  = (String*)CERTIFY(
                                 Hash_Fetch_Utf8(seg_files_data, "filename", 8),
                                 STRING);

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -38,6 +38,7 @@
 #include "Lucy/Search/Query.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Json.h"
 
 DeletionsWriter*
 DelWriter_init(DeletionsWriter *self, Schema *schema, Snapshot *snapshot,
@@ -371,7 +372,7 @@ DefDelWriter_Merge_Segment_IMP(DefaultDeletionsWriter *self,
                          * merge away the most recent deletions file
                          * pointing at this target segment -- so force a
                          * new file to be written out. */
-                        int32_t count = (int32_t)Obj_To_I64(Hash_Fetch_Utf8(mini_meta, "count", 5));
+                        int32_t count = (int32_t)Json_obj_to_i64(Hash_Fetch_Utf8(mini_meta, "count", 5));
                         DeletionsReader *del_reader
                             = (DeletionsReader*)SegReader_Obtain(
                                   candidate, Class_Get_Name(DELETIONSREADER));

--- a/core/Lucy/Index/DocReader.c
+++ b/core/Lucy/Index/DocReader.c
@@ -28,6 +28,7 @@
 #include "Lucy/Plan/Schema.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/InStream.h"
+#include "Lucy/Util/Json.h"
 
 DocReader*
 DocReader_init(DocReader *self, Schema *schema, Folder *folder,
@@ -150,7 +151,7 @@ DefDocReader_init(DefaultDocReader *self, Schema *schema, Folder *folder,
         // Check format.
         if (!format) { THROW(ERR, "Missing 'format' var"); }
         else {
-            int64_t format_val = Obj_To_I64(format);
+            int64_t format_val = Json_obj_to_i64(format);
             if (format_val < DocWriter_current_file_format) {
                 THROW(ERR, "Obsolete doc storage format %i64; "
                       "Index regeneration is required", format_val);

--- a/core/Lucy/Index/FilePurger.c
+++ b/core/Lucy/Index/FilePurger.c
@@ -26,6 +26,7 @@
 #include "Lucy/Store/DirHandle.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/Lock.h"
+#include "Lucy/Util/Json.h"
 
 // Place unused files into purgables array and obsolete Snapshots into
 // snapshots array.
@@ -153,7 +154,7 @@ S_zap_dead_merge(FilePurger *self, Hash *candidates) {
                        : NULL;
 
         if (cutoff) {
-            String *cutoff_seg = Seg_num_to_name(Obj_To_I64(cutoff));
+            String *cutoff_seg = Seg_num_to_name(Json_obj_to_i64(cutoff));
             if (Folder_Exists(ivars->folder, cutoff_seg)) {
                 String *merge_json = SSTR_WRAP_UTF8("merge.json", 10);
                 DirHandle *dh = Folder_Open_Dir(ivars->folder, cutoff_seg);

--- a/core/Lucy/Index/HighlightReader.c
+++ b/core/Lucy/Index/HighlightReader.c
@@ -31,6 +31,7 @@
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Util/Freezer.h"
+#include "Lucy/Util/Json.h"
 
 HighlightReader*
 HLReader_init(HighlightReader *self, Schema *schema, Folder *folder,
@@ -130,9 +131,9 @@ DefHLReader_init(DefaultHighlightReader *self, Schema *schema,
         Obj *format = Hash_Fetch_Utf8(metadata, "format", 6);
         if (!format) { THROW(ERR, "Missing 'format' var"); }
         else {
-            if (Obj_To_I64(format) != HLWriter_current_file_format) {
+            if (Json_obj_to_i64(format) != HLWriter_current_file_format) {
                 THROW(ERR, "Unsupported highlight data format: %i64",
-                      Obj_To_I64(format));
+                      Json_obj_to_i64(format));
             }
         }
     }

--- a/core/Lucy/Index/Indexer.c
+++ b/core/Lucy/Index/Indexer.c
@@ -184,7 +184,7 @@ Indexer_init(Indexer *self, Schema *schema, Obj *index,
             THROW(ERR, "Background merge detected, but can't read merge data");
         }
         else {
-            int64_t cutoff = Obj_To_I64(cutoff_obj);
+            int64_t cutoff = Json_obj_to_i64(cutoff_obj);
             if (cutoff >= new_seg_num) {
                 new_seg_num = cutoff + 1;
             }
@@ -414,7 +414,7 @@ S_maybe_merge(Indexer *self, Vector *seg_readers) {
         if (merge_data) {
             Obj *cutoff_obj = Hash_Fetch_Utf8(merge_data, "cutoff", 6);
             if (cutoff_obj) {
-                cutoff = Obj_To_I64(cutoff_obj);
+                cutoff = Json_obj_to_i64(cutoff_obj);
             }
             else {
                 cutoff = INT64_MAX;

--- a/core/Lucy/Index/PostingListReader.c
+++ b/core/Lucy/Index/PostingListReader.c
@@ -29,6 +29,7 @@
 #include "Lucy/Plan/FieldType.h"
 #include "Lucy/Plan/Schema.h"
 #include "Lucy/Store/Folder.h"
+#include "Lucy/Util/Json.h"
 
 PostingListReader*
 PListReader_init(PostingListReader *self, Schema *schema, Folder *folder,
@@ -80,9 +81,9 @@ DefPListReader_init(DefaultPostingListReader *self, Schema *schema,
         Obj *format = Hash_Fetch_Utf8(my_meta, "format", 6);
         if (!format) { THROW(ERR, "Missing 'format' var"); }
         else {
-            if (Obj_To_I64(format) != PListWriter_current_file_format) {
+            if (Json_obj_to_i64(format) != PListWriter_current_file_format) {
                 THROW(ERR, "Unsupported postings format: %i64",
-                      Obj_To_I64(format));
+                      Json_obj_to_i64(format));
             }
         }
     }

--- a/core/Lucy/Index/SegLexicon.c
+++ b/core/Lucy/Index/SegLexicon.c
@@ -31,6 +31,7 @@
 #include "Lucy/Plan/Schema.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/InStream.h"
+#include "Lucy/Util/Json.h"
 
 // Iterate until the state is greater than or equal to the target.
 static void
@@ -63,9 +64,9 @@ SegLex_init(SegLexicon *self, Schema *schema, Folder *folder,
     // Check format.
     if (!format) { THROW(ERR, "Missing 'format'"); }
     else {
-        if (Obj_To_I64(format) > LexWriter_current_file_format) {
+        if (Json_obj_to_i64(format) > LexWriter_current_file_format) {
             THROW(ERR, "Unsupported lexicon format: %i64",
-                  Obj_To_I64(format));
+                  Json_obj_to_i64(format));
         }
     }
 
@@ -73,7 +74,7 @@ SegLex_init(SegLexicon *self, Schema *schema, Folder *folder,
     if (!counts) { THROW(ERR, "Failed to extract 'counts'"); }
     else {
         Obj *count = CERTIFY(Hash_Fetch(counts, field), OBJ);
-        ivars->size = (int32_t)Obj_To_I64(count);
+        ivars->size = (int32_t)Json_obj_to_i64(count);
     }
 
     // Assign.

--- a/core/Lucy/Index/Segment.c
+++ b/core/Lucy/Index/Segment.c
@@ -113,7 +113,7 @@ Seg_Read_File_IMP(Segment *self, Folder *folder) {
     Obj *count = Hash_Fetch_Utf8(my_metadata, "count", 5);
     if (!count) { count = Hash_Fetch_Utf8(my_metadata, "doc_count", 9); }
     if (!count) { THROW(ERR, "Missing 'count'"); }
-    else { ivars->count = Obj_To_I64(count); }
+    else { ivars->count = Json_obj_to_i64(count); }
 
     // Get list of field nums.
     Vector *source_by_num = (Vector*)Hash_Fetch_Utf8(my_metadata,

--- a/core/Lucy/Index/Snapshot.c
+++ b/core/Lucy/Index/Snapshot.c
@@ -115,10 +115,10 @@ Snapshot_Read_File_IMP(Snapshot *self, Folder *folder, String *path) {
             = (Hash*)CERTIFY(Json_slurp_json(folder, ivars->path), HASH);
         Obj *format_obj
             = CERTIFY(Hash_Fetch_Utf8(snap_data, "format", 6), OBJ);
-        int32_t format = (int32_t)Obj_To_I64(format_obj);
+        int32_t format = (int32_t)Json_obj_to_i64(format_obj);
         Obj *subformat_obj = Hash_Fetch_Utf8(snap_data, "subformat", 9);
         int32_t subformat = subformat_obj
-                            ? (int32_t)Obj_To_I64(subformat_obj)
+                            ? (int32_t)Json_obj_to_i64(subformat_obj)
                             : 0;
 
         // Verify that we can read the index properly.

--- a/core/Lucy/Index/SortReader.c
+++ b/core/Lucy/Index/SortReader.c
@@ -28,6 +28,7 @@
 #include "Lucy/Plan/Schema.h"
 #include "Lucy/Store/Folder.h"
 #include "Lucy/Store/InStream.h"
+#include "Lucy/Util/Json.h"
 
 SortReader*
 SortReader_init(SortReader *self, Schema *schema, Folder *folder,
@@ -71,7 +72,7 @@ DefSortReader_init(DefaultSortReader *self, Schema *schema, Folder *folder,
         Obj *format = Hash_Fetch_Utf8(metadata, "format", 6);
         if (!format) { THROW(ERR, "Missing 'format' var"); }
         else {
-            ivars->format = (int32_t)Obj_To_I64(format);
+            ivars->format = (int32_t)Json_obj_to_i64(format);
             if (ivars->format < 2 || ivars->format > 3) {
                 THROW(ERR, "Unsupported sort cache format: %i32",
                       ivars->format);
@@ -160,7 +161,7 @@ S_lazy_init_sort_cache(DefaultSortReader *self, String *field) {
 
     // See if we have any values.
     Obj *count_obj = Hash_Fetch(ivars->counts, field);
-    int32_t count = count_obj ? (int32_t)Obj_To_I64(count_obj) : 0;
+    int32_t count = count_obj ? (int32_t)Json_obj_to_i64(count_obj) : 0;
     if (!count) { return NULL; }
 
     // Get a FieldType and sanity check that the field is sortable.
@@ -205,10 +206,10 @@ S_lazy_init_sort_cache(DefaultSortReader *self, String *field) {
     }
 
     Obj     *null_ord_obj = Hash_Fetch(ivars->null_ords, field);
-    int32_t  null_ord = null_ord_obj ? (int32_t)Obj_To_I64(null_ord_obj) : -1;
+    int32_t  null_ord = null_ord_obj ? (int32_t)Json_obj_to_i64(null_ord_obj) : -1;
     Obj     *ord_width_obj = Hash_Fetch(ivars->ord_widths, field);
     int32_t  ord_width = ord_width_obj
-                         ? (int32_t)Obj_To_I64(ord_width_obj)
+                         ? (int32_t)Json_obj_to_i64(ord_width_obj)
                          : S_calc_ord_width(count);
     int32_t  doc_max = (int32_t)Seg_Get_Count(segment);
 

--- a/core/Lucy/Plan/BlobType.c
+++ b/core/Lucy/Plan/BlobType.c
@@ -18,6 +18,7 @@
 #include "Lucy/Util/ToolSet.h"
 
 #include "Lucy/Plan/BlobType.h"
+#include "Lucy/Util/Json.h"
 
 BlobType*
 BlobType_new(bool stored) {
@@ -107,13 +108,13 @@ BlobType_Load_IMP(BlobType *self, Obj *dump) {
     BlobType_init(loaded, false);
     BlobTypeIVARS *const loaded_ivars = BlobType_IVARS(loaded);
     if (boost_dump) {
-        loaded_ivars->boost = (float)Obj_To_F64(boost_dump);
+        loaded_ivars->boost = (float)Json_obj_to_f64(boost_dump);
     }
     if (indexed_dump) {
-        loaded_ivars->indexed = Obj_To_Bool(indexed_dump);
+        loaded_ivars->indexed = Json_obj_to_bool(indexed_dump);
     }
     if (stored_dump){
-        loaded_ivars->stored = Obj_To_Bool(stored_dump);
+        loaded_ivars->stored = Json_obj_to_bool(stored_dump);
     }
 
     return loaded;

--- a/core/Lucy/Plan/FullTextType.c
+++ b/core/Lucy/Plan/FullTextType.c
@@ -22,6 +22,7 @@
 #include "Lucy/Index/Posting/ScorePosting.h"
 #include "Lucy/Index/Similarity.h"
 #include "Lucy/Util/Freezer.h"
+#include "Lucy/Util/Json.h"
 
 FullTextType*
 FullTextType_new(Analyzer *analyzer) {
@@ -129,17 +130,17 @@ FullTextType_Load_IMP(FullTextType *self, Obj *dump) {
 
     // Extract boost.
     Obj *boost_dump = Hash_Fetch_Utf8(source, "boost", 5);
-    float boost = boost_dump ? (float)Obj_To_F64(boost_dump) : 1.0f;
+    float boost = boost_dump ? (float)Json_obj_to_f64(boost_dump) : 1.0f;
 
     // Find boolean properties.
     Obj *indexed_dump = Hash_Fetch_Utf8(source, "indexed", 7);
     Obj *stored_dump  = Hash_Fetch_Utf8(source, "stored", 6);
     Obj *sort_dump    = Hash_Fetch_Utf8(source, "sortable", 8);
     Obj *hl_dump      = Hash_Fetch_Utf8(source, "highlightable", 13);
-    bool indexed  = indexed_dump ? Obj_To_Bool(indexed_dump) : true;
-    bool stored   = stored_dump  ? Obj_To_Bool(stored_dump)  : true;
-    bool sortable = sort_dump    ? Obj_To_Bool(sort_dump)    : false;
-    bool hl       = hl_dump      ? Obj_To_Bool(hl_dump)      : false;
+    bool indexed  = indexed_dump ? Json_obj_to_bool(indexed_dump) : true;
+    bool stored   = stored_dump  ? Json_obj_to_bool(stored_dump)  : true;
+    bool sortable = sort_dump    ? Json_obj_to_bool(sort_dump)    : false;
+    bool hl       = hl_dump      ? Json_obj_to_bool(hl_dump)      : false;
 
     // Extract an Analyzer.
     Obj *analyzer_dump = Hash_Fetch_Utf8(source, "analyzer", 8);

--- a/core/Lucy/Plan/NumericType.c
+++ b/core/Lucy/Plan/NumericType.c
@@ -18,6 +18,7 @@
 #include "Lucy/Util/ToolSet.h"
 
 #include "Lucy/Plan/NumericType.h"
+#include "Lucy/Util/Json.h"
 
 NumericType*
 NumType_init(NumericType *self) {
@@ -108,15 +109,15 @@ NumType_Load_IMP(NumericType *self, Obj *dump) {
 
     // Extract boost.
     Obj *boost_dump = Hash_Fetch_Utf8(source, "boost", 5);
-    float boost = boost_dump ? (float)Obj_To_F64(boost_dump) : 1.0f;
+    float boost = boost_dump ? (float)Json_obj_to_f64(boost_dump) : 1.0f;
 
     // Find boolean properties.
     Obj *indexed_dump = Hash_Fetch_Utf8(source, "indexed", 7);
     Obj *stored_dump  = Hash_Fetch_Utf8(source, "stored", 6);
     Obj *sort_dump    = Hash_Fetch_Utf8(source, "sortable", 8);
-    bool indexed  = indexed_dump ? Obj_To_Bool(indexed_dump) : true;
-    bool stored   = stored_dump  ? Obj_To_Bool(stored_dump)  : true;
-    bool sortable = sort_dump    ? Obj_To_Bool(sort_dump)    : false;
+    bool indexed  = indexed_dump ? Json_obj_to_bool(indexed_dump) : true;
+    bool stored   = stored_dump  ? Json_obj_to_bool(stored_dump)  : true;
+    bool sortable = sort_dump    ? Json_obj_to_bool(sort_dump)    : false;
 
     return NumType_init2(loaded, boost, indexed, stored, sortable);
 }

--- a/core/Lucy/Plan/Schema.c
+++ b/core/Lucy/Plan/Schema.c
@@ -336,7 +336,7 @@ Schema_Load_IMP(Schema *self, Obj *dump) {
                     = CERTIFY(Hash_Fetch_Utf8(type_dump, "analyzer", 8), OBJ);
                 Analyzer *analyzer
                     = (Analyzer*)Vec_Fetch(analyzers,
-                                          (uint32_t)Obj_To_I64(tick));
+                                          (uint32_t)Json_obj_to_i64(tick));
                 if (!analyzer) {
                     THROW(ERR, "Can't find analyzer for '%o'", field);
                 }

--- a/core/Lucy/Plan/StringType.c
+++ b/core/Lucy/Plan/StringType.c
@@ -20,6 +20,7 @@
 #include "Lucy/Plan/StringType.h"
 #include "Lucy/Index/Posting/ScorePosting.h"
 #include "Lucy/Index/Similarity.h"
+#include "Lucy/Util/Json.h"
 
 StringType*
 StringType_new() {
@@ -101,10 +102,10 @@ StringType_Load_IMP(StringType *self, Obj *dump) {
     Obj *sortable_dump   = Hash_Fetch_Utf8(source, "sortable", 8);
     UNUSED_VAR(self);
 
-    float boost    = boost_dump    ? (float)Obj_To_F64(boost_dump) : 1.0f;
-    bool  indexed  = indexed_dump  ? Obj_To_Bool(indexed_dump)     : true;
-    bool  stored   = stored_dump   ? Obj_To_Bool(stored_dump)      : true;
-    bool  sortable = sortable_dump ? Obj_To_Bool(sortable_dump)    : false;
+    float boost    = boost_dump    ? (float)Json_obj_to_f64(boost_dump) : 1.0f;
+    bool  indexed  = indexed_dump  ? Json_obj_to_bool(indexed_dump)     : true;
+    bool  stored   = stored_dump   ? Json_obj_to_bool(stored_dump)      : true;
+    bool  sortable = sortable_dump ? Json_obj_to_bool(sortable_dump)    : false;
 
     return StringType_init2(loaded, boost, indexed, stored, sortable);
 }

--- a/core/Lucy/Plan/TextType.c
+++ b/core/Lucy/Plan/TextType.c
@@ -65,7 +65,7 @@ void
 TextTermStepper_Set_Value_IMP(TextTermStepper *self, Obj *value) {
     TextTermStepperIVARS *const ivars = TextTermStepper_IVARS(self);
     CERTIFY(value, STRING);
-    Obj_Mimic(ivars->value, value);
+    CB_Mimic((CharBuf*)ivars->value, value);
     // Invalidate string.
     DECREF(ivars->string);
     ivars->string = NULL;

--- a/core/Lucy/Search/NoMatchQuery.c
+++ b/core/Lucy/Search/NoMatchQuery.c
@@ -26,6 +26,7 @@
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Util/Freezer.h"
+#include "Lucy/Util/Json.h"
 
 NoMatchQuery*
 NoMatchQuery_new() {
@@ -96,7 +97,7 @@ NoMatchQuery_Load_IMP(NoMatchQuery *self, Obj *dump) {
     NoMatchQuery *loaded = super_load(self, dump);
     Obj *fails = CFISH_Hash_Fetch_Utf8(source, "fails_to_match", 14);
     NoMatchQuery_IVARS(loaded)->fails_to_match
-        = fails ? Obj_To_Bool(fails) : true;
+        = fails ? Json_obj_to_bool(fails) : true;
     return loaded;
 }
 

--- a/core/Lucy/Search/Query.c
+++ b/core/Lucy/Search/Query.c
@@ -22,6 +22,7 @@
 #include "Lucy/Search/Searcher.h"
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Json.h"
 
 Query*
 Query_init(Query *self, float boost) {
@@ -71,7 +72,7 @@ Query_Load_IMP(Query *self, Obj *dump) {
     Class *klass  = Class_singleton(class_name, NULL);
     Query *loaded = (Query*)Class_Make_Obj(klass);
     Obj *boost = CERTIFY(Hash_Fetch_Utf8(source, "boost", 5), OBJ);
-    Query_IVARS(loaded)->boost = (float)Obj_To_F64(boost);
+    Query_IVARS(loaded)->boost = (float)Json_obj_to_f64(boost);
     return (Obj*)loaded;
 }
 

--- a/core/Lucy/Search/RangeQuery.c
+++ b/core/Lucy/Search/RangeQuery.c
@@ -31,6 +31,7 @@
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Util/Freezer.h"
+#include "Lucy/Util/Json.h"
 
 // Determine the lowest ordinal that should match.
 static int32_t
@@ -203,10 +204,10 @@ RangeQuery_Load_IMP(RangeQuery *self, Obj *dump) {
     }
     Obj *include_lower
         = CERTIFY(Hash_Fetch_Utf8(source, "include_lower", 13), OBJ);
-    loaded_ivars->include_lower = Obj_To_Bool(include_lower);
+    loaded_ivars->include_lower = Json_obj_to_bool(include_lower);
     Obj *include_upper
         = CERTIFY(Hash_Fetch_Utf8(source, "include_upper", 13), OBJ);
-    loaded_ivars->include_upper = Obj_To_Bool(include_upper);
+    loaded_ivars->include_upper = Json_obj_to_bool(include_upper);
     return (Obj*)loaded;
 }
 

--- a/core/Lucy/Store/CompoundFileReader.c
+++ b/core/Lucy/Store/CompoundFileReader.c
@@ -51,7 +51,7 @@ CFReader_do_open(CompoundFileReader *self, Folder *folder) {
     }
     else {
         Obj *format = Hash_Fetch_Utf8(metadata, "format", 6);
-        ivars->format = format ? (int32_t)Obj_To_I64(format) : 0;
+        ivars->format = format ? (int32_t)Json_obj_to_i64(format) : 0;
         ivars->records = (Hash*)INCREF(Hash_Fetch_Utf8(metadata, "files", 5));
         if (ivars->format < 1) {
             error = Err_new(Str_newf("Corrupt %o file: Missing or invalid 'format'",
@@ -206,13 +206,13 @@ CFReader_Local_Open_In_IMP(CompoundFileReader *self, String *name) {
         else if (Str_Get_Size(ivars->path)) {
             String *fullpath = Str_newf("%o/%o", ivars->path, name);
             InStream *instream = InStream_Reopen(ivars->instream, fullpath,
-                                                 Obj_To_I64(offset), Obj_To_I64(len));
+                                                 Json_obj_to_i64(offset), Json_obj_to_i64(len));
             DECREF(fullpath);
             return instream;
         }
         else {
-            return InStream_Reopen(ivars->instream, name, Obj_To_I64(offset),
-                                   Obj_To_I64(len));
+            return InStream_Reopen(ivars->instream, name, Json_obj_to_i64(offset),
+                                   Json_obj_to_i64(len));
         }
     }
 }

--- a/core/Lucy/Test/Search/TestSortSpec.c
+++ b/core/Lucy/Test/Search/TestSortSpec.c
@@ -237,16 +237,15 @@ S_add_vehicle(Indexer *indexer, String *name, int32_t speed, int32_t sloth,
     Doc_Store(doc, home_str, (Obj*)home);
     Doc_Store(doc, cat_str,  (Obj*)cat);
 
-    String *string;
-    string = Str_newf("%i32", speed);
-    Doc_Store(doc, speed_str, (Obj*)string);
-    DECREF(string);
-    string = Str_newf("%i32", sloth);
-    Doc_Store(doc, sloth_str, (Obj*)string);
-    DECREF(string);
-    string = Str_newf("%i32", weight);
-    Doc_Store(doc, weight_str, (Obj*)string);
-    DECREF(string);
+    Integer32 *speed_obj = Int32_new(speed);
+    Doc_Store(doc, speed_str, (Obj*)speed_obj);
+    DECREF(speed_obj);
+    Integer32 *sloth_obj = Int32_new(sloth);
+    Doc_Store(doc, sloth_str, (Obj*)sloth_obj);
+    DECREF(sloth_obj);
+    Integer32 *weight_obj = Int32_new(weight);
+    Doc_Store(doc, weight_str, (Obj*)weight_obj);
+    DECREF(weight_obj);
 
     Indexer_Add_Doc(indexer, doc, 1.0f);
 
@@ -254,13 +253,13 @@ S_add_vehicle(Indexer *indexer, String *name, int32_t speed, int32_t sloth,
 }
 
 static void
-S_add_doc(Indexer *indexer, Obj *name_obj, String *cat, String *field_name) {
+S_add_doc(Indexer *indexer, Obj *value, String *cat, String *field_name) {
     Doc *doc = Doc_new(NULL, 0);
-    String *name = Obj_To_String(name_obj);
+    String *name = Obj_To_String(value);
     Doc_Store(doc, name_str, (Obj*)name);
     Doc_Store(doc, cat_str,  (Obj*)cat);
     if (field_name) {
-        Doc_Store(doc, field_name, (Obj*)name);
+        Doc_Store(doc, field_name, value);
     }
     Indexer_Add_Doc(indexer, doc, 1.0f);
     DECREF(name);

--- a/core/Lucy/Test/Store/TestCompoundFileWriter.c
+++ b/core/Lucy/Test/Store/TestCompoundFileWriter.c
@@ -128,7 +128,7 @@ test_offsets(TestBatchRunner *runner) {
         String *file   = HashIter_Get_Key(iter);
         Hash   *stats  = (Hash*)CERTIFY(HashIter_Get_Value(iter), HASH);
         Obj    *offset = CERTIFY(Hash_Fetch_Utf8(stats, "offset", 6), OBJ);
-        int64_t offs   = Obj_To_I64(offset);
+        int64_t offs   = Json_obj_to_i64(offset);
         if (offs % 8 != 0) {
             offsets_ok = false;
             FAIL(runner, "Offset %" PRId64 " for %s not a multiple of 8",

--- a/core/Lucy/Util/Json.c
+++ b/core/Lucy/Util/Json.c
@@ -282,10 +282,10 @@ S_to_json(Obj *dump, CharBuf *buf, int32_t depth) {
         S_append_json_string((String*)dump, buf);
     }
     else if (Obj_Is_A(dump, INTNUM)) {
-        CB_catf(buf, "%i64", Obj_To_I64(dump));
+        CB_catf(buf, "%i64", IntNum_To_I64((IntNum*)dump));
     }
     else if (Obj_Is_A(dump, FLOATNUM)) {
-        CB_catf(buf, "%f64", Obj_To_F64(dump));
+        CB_catf(buf, "%f64", FloatNum_To_F64((FloatNum*)dump));
     }
     else if (Obj_Is_A(dump, VECTOR)) {
         Vector *array = (Vector*)dump;

--- a/core/Lucy/Util/Json.c
+++ b/core/Lucy/Util/Json.c
@@ -701,3 +701,66 @@ S_set_error(CharBuf *buf, const char *json, const char *limit, int line,
     Err_set_error(Err_new(mess));
 }
 
+int64_t
+Json_obj_to_i64(Obj *obj) {
+    int64_t retval = 0;
+
+    if (!obj) {
+        THROW(ERR, "Can't extract integer from NULL");
+    }
+    else if (Obj_Is_A(obj, STRING)) {
+        retval = Str_To_I64((String*)obj);
+    }
+    else if (Obj_Is_A(obj, NUM)) {
+        retval = Num_To_I64((Num*)obj);
+    }
+    else {
+        THROW(ERR, "Can't extract integer from object of type %o",
+              Obj_Get_Class_Name(obj));
+    }
+
+    return retval;
+}
+
+double
+Json_obj_to_f64(Obj *obj) {
+    double retval = 0;
+
+    if (!obj) {
+        THROW(ERR, "Can't extract float from NULL");
+    }
+    else if (Obj_Is_A(obj, STRING)) {
+        retval = Str_To_F64((String*)obj);
+    }
+    else if (Obj_Is_A(obj, NUM)) {
+        retval = Num_To_F64((Num*)obj);
+    }
+    else {
+        THROW(ERR, "Can't extract float from object of type %o",
+              Obj_Get_Class_Name(obj));
+    }
+
+    return retval;
+}
+
+bool
+Json_obj_to_bool(Obj *obj) {
+    bool retval = false;
+
+    if (!obj) {
+        THROW(ERR, "Can't extract bool from NULL");
+    }
+    else if (Obj_Is_A(obj, STRING)) {
+        retval = (Str_To_I64((String*)obj) != 0);
+    }
+    else if (Obj_Is_A(obj, NUM)) {
+        retval = Num_To_Bool((Num*)obj);
+    }
+    else {
+        THROW(ERR, "Can't extract bool from object of type %o",
+              Obj_Get_Class_Name(obj));
+    }
+
+    return retval;
+}
+

--- a/core/Lucy/Util/Json.cfh
+++ b/core/Lucy/Util/Json.cfh
@@ -57,6 +57,24 @@ class Lucy::Util::Json inherits Clownfish::Obj {
      */
     inert void
     set_tolerant(bool tolerant);
+
+    /** Extract an integer value from an object that is part of a JSON
+     * structure. Throws an error if the object isn't a String or Num.
+     */
+    inert int64_t
+    obj_to_i64(Obj *obj);
+
+    /** Extract a float value from an object that is part of a JSON
+     * structure. Throws an error if the object isn't a String or Num.
+     */
+    inert double
+    obj_to_f64(Obj *obj);
+
+    /** Extract a bool value from an object that is part of a JSON
+     * structure. Throws an error if the object isn't a String or Num.
+     */
+    inert bool
+    obj_to_bool(Obj *obj);
 }
 
 

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -39,6 +39,7 @@
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Util/Freezer.h"
+#include "Lucy/Util/Json.h"
 
 // Shared initialization routine which assumes that it's ok to assume control
 // over [field] and [terms], eating their refcounts.
@@ -123,7 +124,7 @@ ProximityQuery_Load_IMP(ProximityQuery *self, Obj *dump) {
     Obj *terms = CERTIFY(Hash_Fetch_Utf8(source, "terms", 5), OBJ);
     loaded_ivars->terms = (Vector*)CERTIFY(Freezer_load(terms), VECTOR);
     Obj *within = CERTIFY(Hash_Fetch_Utf8(source, "within", 6), OBJ);
-    loaded_ivars->within = (uint32_t)Obj_To_I64(within);
+    loaded_ivars->within = (uint32_t)Json_obj_to_i64(within);
     return (Obj*)loaded;
 }
 

--- a/perl/xs/Lucy/Document/Doc.c
+++ b/perl/xs/Lucy/Document/Doc.c
@@ -19,6 +19,7 @@
 #include "Lucy/Document/Doc.h"
 #include "Lucy/Store/InStream.h"
 #include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Json.h"
 #include "Clownfish/Util/Memory.h"
 
 lucy_Doc*
@@ -191,7 +192,7 @@ LUCY_Doc_Load_IMP(lucy_Doc *self, cfish_Obj *dump) {
     CFISH_UNUSED_VAR(self);
 
     lucy_DocIVARS *const loaded_ivars = lucy_Doc_IVARS(loaded);
-    loaded_ivars->doc_id = (int32_t)CFISH_Obj_To_I64(doc_id);
+    loaded_ivars->doc_id = (int32_t)lucy_Json_obj_to_i64(doc_id);
     loaded_ivars->fields  = SvREFCNT_inc(SvRV(fields_sv));
     SvREFCNT_dec(fields_sv);
 


### PR DESCRIPTION
This pull request contains some more or less unrelated changes to the way number fields are handled. It turned out that the Perl bindings didn't support storing Num objects in number fields from C space. The behavior of number fields in the C bindings has changed, too. Automatic conversion from Strings to Nums isn't supported anymore. There are different ways to reenable this feature, although I don't think it's important.