### PR TITLE
LUCY-281 Go/CGO port

### DIFF
--- a/c/src/Lucy/Analysis/RegexTokenizer.c
+++ b/c/src/Lucy/Analysis/RegexTokenizer.c
@@ -87,13 +87,6 @@ RegexTokenizer_init(RegexTokenizer *self, String *pattern) {
 }
 
 void
-RegexTokenizer_Set_Token_RE_IMP(RegexTokenizer *self, void *token_re) {
-    UNUSED_VAR(self);
-    UNUSED_VAR(token_re);
-    THROW(ERR, "TODO");
-}
-
-void
 RegexTokenizer_Destroy_IMP(RegexTokenizer *self) {
     RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
     DECREF(ivars->pattern);

--- a/common/charmonizer.c
+++ b/common/charmonizer.c
@@ -8134,7 +8134,7 @@ lucy_MakeFile_new(chaz_CLI *cli) {
         self->host_src_dir = "xs";
     }
 	else if (chaz_CLI_defined(cli, "enable-go")) {
-        self->host_src_dir = "../c/src";
+        self->host_src_dir = "cfext";
 	}
     else {
         self->host_src_dir = "src";

--- a/common/charmonizer.main
+++ b/common/charmonizer.main
@@ -252,7 +252,7 @@ lucy_MakeFile_new(chaz_CLI *cli) {
         self->host_src_dir = "xs";
     }
 	else if (chaz_CLI_defined(cli, "enable-go")) {
-        self->host_src_dir = "../c/src";
+        self->host_src_dir = "cfext";
 	}
     else {
         self->host_src_dir = "src";

--- a/core/Lucy/Analysis/RegexTokenizer.cfh
+++ b/core/Lucy/Analysis/RegexTokenizer.cfh
@@ -84,12 +84,6 @@ public class Lucy::Analysis::RegexTokenizer
     Tokenize_Utf8(RegexTokenizer *self, const char *text, size_t len,
                   Inversion *inversion);
 
-    /** Set the compiled regular expression for matching a token.  Also sets
-     * `pattern` as a side effect.
-     */
-    void
-    Set_Token_RE(RegexTokenizer *self, void *token_re);
-
     public incremented Obj*
     Dump(RegexTokenizer *self);
 

--- a/example-lang/src/Lucy/Analysis/RegexTokenizer.c
+++ b/example-lang/src/Lucy/Analysis/RegexTokenizer.c
@@ -29,11 +29,6 @@ lucy_RegexTokenizer_init(lucy_RegexTokenizer *self,
 }
 
 void
-lucy_RegexTokenizer_set_token_re(lucy_RegexTokenizer *self, void *token_re) {
-    THROW(LUCY_ERR, "TODO");
-}
-
-void
 lucy_RegexTokenizer_destroy(lucy_RegexTokenizer *self) {
     THROW(LUCY_ERR, "TODO");
 }

--- a/go/cfext/lucy.c
+++ b/go/cfext/lucy.c
@@ -55,174 +55,33 @@
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Util/Freezer.h"
 
-#if defined(CHY_HAS_PCRE_H)
-
-#include <pcre.h>
-
-static uint32_t
-S_count_code_points(const char *string, size_t len);
-
-bool
-RegexTokenizer_is_available(void) {
-    return true;
-}
-
-RegexTokenizer*
-RegexTokenizer_init(RegexTokenizer *self, String *pattern) {
-    Analyzer_init((Analyzer*)self);
-    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
-
-    char *pattern_buf = NULL;
-    const char *pattern_ptr;
-    if (pattern) {
-        ivars->pattern = Str_Clone(pattern);
-        pattern_buf = Str_To_Utf8(ivars->pattern);
-        pattern_ptr = pattern_buf;
-    }
-    else {
-        pattern_ptr = "\\w+(?:['\\x{2019}]\\w+)*";
-        ivars->pattern
-            = Str_new_from_trusted_utf8(pattern_ptr, strlen(pattern_ptr));
-    }
-
-    int options = PCRE_UTF8 | PCRE_NO_UTF8_CHECK;
-#ifdef PCRE_BSR_UNICODE
-    // Available since PCRE 7.4
-    options |= PCRE_BSR_UNICODE;
-#endif
-#ifdef PCRE_NEWLINE_LF
-    // Available since PCRE 6.7
-    options |= PCRE_NEWLINE_LF;
-#endif
-    const char *err_ptr;
-    int err_offset;
-    pcre *re = pcre_compile(pattern_ptr, options, &err_ptr, &err_offset, NULL);
-    if (pattern_buf) {
-        FREEMEM(pattern_buf);
-    }
-    if (!re) {
-        THROW(ERR, "%s", err_ptr);
-    }
-
-    // TODO: Check whether pcre_study improves performance
-
-    ivars->token_re = re;
-
-    return self;
-}
-
-void
-RegexTokenizer_Destroy_IMP(RegexTokenizer *self) {
-    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
-    DECREF(ivars->pattern);
-    pcre *re = (pcre*)ivars->token_re;
-    if (re) {
-        pcre_free(re);
-    }
-    SUPER_DESTROY(self, REGEXTOKENIZER);
-}
-
-void
-RegexTokenizer_Tokenize_Utf8_IMP(RegexTokenizer *self, const char *string,
-                                 size_t string_len, Inversion *inversion) {
-    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
-    pcre      *re          = (pcre*)ivars->token_re;
-    int        byte_offset = 0;
-    uint32_t   cp_offset   = 0; // Code points
-    int        options     = PCRE_NO_UTF8_CHECK;
-    int        ovector[3];
-
-    int return_code = pcre_exec(re, NULL, string, string_len, byte_offset,
-                                options, ovector, 3);
-    while (return_code >= 0) {
-        const char *match     = string + ovector[0];
-        size_t      match_len = ovector[1] - ovector[0];
-
-        uint32_t cp_before  = S_count_code_points(string + byte_offset,
-                                                  ovector[0] - byte_offset);
-        uint32_t cp_start   = cp_offset + cp_before;
-        uint32_t cp_matched = S_count_code_points(match, match_len);
-        uint32_t cp_end     = cp_start + cp_matched;
-
-        // Add a token to the new inversion.
-        Token *token = Token_new(match, match_len, cp_start, cp_end, 1.0f, 1);
-        Inversion_Append(inversion, token);
-
-        byte_offset = ovector[1];
-        cp_offset   = cp_end;
-        return_code = pcre_exec(re, NULL, string, string_len, byte_offset,
-                                options, ovector, 3);
-    }
-
-    if (return_code != PCRE_ERROR_NOMATCH) {
-        THROW(ERR, "pcre_exec failed: %d", return_code);
-    }
-}
-
-static uint32_t
-S_count_code_points(const char *string, size_t len) {
-    uint32_t num_code_points = 0;
-    size_t i = 0;
-
-    while (i < len) {
-        i += StrHelp_UTF8_COUNT[(uint8_t)(string[i])];
-        ++num_code_points;
-    }
-
-    if (i != len) {
-        THROW(ERR, "Match between code point boundaries in '%s'", string);
-    }
-
-    return num_code_points;
-}
-
-#else // CHY_HAS_PCRE_H
-
 bool
 RegexTokenizer_is_available(void) {
     return false;
 }
 
 RegexTokenizer*
+(*GOLUCY_RegexTokenizer_init_BRIDGE)(RegexTokenizer *self, String *pattern);
+
+RegexTokenizer*
 RegexTokenizer_init(RegexTokenizer *self, String *pattern) {
-    UNUSED_VAR(self);
-    UNUSED_VAR(pattern);
-    THROW(ERR,
-          "RegexTokenizer is not available because Lucy was compiled"
-          " without PCRE.");
-    UNREACHABLE_RETURN(RegexTokenizer*);
+    return GOLUCY_RegexTokenizer_init_BRIDGE(self, pattern);
 }
 
-void
-RegexTokenizer_Set_Token_RE_IMP(RegexTokenizer *self, void *token_re) {
-    UNUSED_VAR(self);
-    UNUSED_VAR(token_re);
-    THROW(ERR,
-          "RegexTokenizer is not available because Lucy was compiled"
-          " without PCRE.");
-}
+RegexTokenizer_Destroy_t GOLUCY_RegexTokenizer_Destroy_BRIDGE;
 
 void
 RegexTokenizer_Destroy_IMP(RegexTokenizer *self) {
-    UNUSED_VAR(self);
-    THROW(ERR,
-          "RegexTokenizer is not available because Lucy was compiled"
-          " without PCRE.");
+    GOLUCY_RegexTokenizer_Destroy_BRIDGE(self);
 }
+
+RegexTokenizer_Tokenize_Utf8_t GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE;
 
 void
 RegexTokenizer_Tokenize_Utf8_IMP(RegexTokenizer *self, const char *string,
                                  size_t string_len, Inversion *inversion) {
-    UNUSED_VAR(self);
-    UNUSED_VAR(string);
-    UNUSED_VAR(string_len);
-    UNUSED_VAR(inversion);
-    THROW(ERR,
-          "RegexTokenizer is not available because Lucy was compiled"
-          " without PCRE.");
+    GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE(self, string, string_len, inversion);
 }
-
-#endif // CHY_HAS_PCRE_H
 
 /********************************** Doc ********************************/
 

--- a/go/cfext/lucy.c
+++ b/go/cfext/lucy.c
@@ -1,0 +1,483 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+#define C_LUCY_REGEXTOKENIZER
+#define C_LUCY_DOC
+#define C_LUCY_DOCREADER
+#define C_LUCY_DEFAULTDOCREADER
+#define C_LUCY_INVERTER
+#define C_LUCY_INVERTERENTRY
+#define CFISH_USE_SHORT_NAMES
+#define LUCY_USE_SHORT_NAMES
+
+
+
+#include <string.h>
+
+#include "charmony.h"
+
+#include "Lucy/Analysis/RegexTokenizer.h"
+#include "Lucy/Document/Doc.h"
+#include "Lucy/Index/DocReader.h"
+#include "Lucy/Index/Inverter.h"
+#include "Clownfish/Blob.h"
+#include "Clownfish/String.h"
+#include "Clownfish/Err.h"
+#include "Clownfish/Hash.h"
+#include "Clownfish/HashIterator.h"
+#include "Clownfish/Num.h"
+#include "Clownfish/Vector.h"
+#include "Clownfish/Class.h"
+#include "Clownfish/Util/Memory.h"
+#include "Clownfish/Util/StringHelper.h"
+#include "Lucy/Analysis/Token.h"
+#include "Lucy/Analysis/Inversion.h"
+#include "Lucy/Document/HitDoc.h"
+#include "Lucy/Index/Segment.h"
+#include "Lucy/Plan/FieldType.h"
+#include "Lucy/Plan/Schema.h"
+#include "Lucy/Store/InStream.h"
+#include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Freezer.h"
+
+#if defined(CHY_HAS_PCRE_H)
+
+#include <pcre.h>
+
+static uint32_t
+S_count_code_points(const char *string, size_t len);
+
+bool
+RegexTokenizer_is_available(void) {
+    return true;
+}
+
+RegexTokenizer*
+RegexTokenizer_init(RegexTokenizer *self, String *pattern) {
+    Analyzer_init((Analyzer*)self);
+    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
+
+    char *pattern_buf = NULL;
+    const char *pattern_ptr;
+    if (pattern) {
+        ivars->pattern = Str_Clone(pattern);
+        pattern_buf = Str_To_Utf8(ivars->pattern);
+        pattern_ptr = pattern_buf;
+    }
+    else {
+        pattern_ptr = "\\w+(?:['\\x{2019}]\\w+)*";
+        ivars->pattern
+            = Str_new_from_trusted_utf8(pattern_ptr, strlen(pattern_ptr));
+    }
+
+    int options = PCRE_UTF8 | PCRE_NO_UTF8_CHECK;
+#ifdef PCRE_BSR_UNICODE
+    // Available since PCRE 7.4
+    options |= PCRE_BSR_UNICODE;
+#endif
+#ifdef PCRE_NEWLINE_LF
+    // Available since PCRE 6.7
+    options |= PCRE_NEWLINE_LF;
+#endif
+    const char *err_ptr;
+    int err_offset;
+    pcre *re = pcre_compile(pattern_ptr, options, &err_ptr, &err_offset, NULL);
+    if (pattern_buf) {
+        FREEMEM(pattern_buf);
+    }
+    if (!re) {
+        THROW(ERR, "%s", err_ptr);
+    }
+
+    // TODO: Check whether pcre_study improves performance
+
+    ivars->token_re = re;
+
+    return self;
+}
+
+void
+RegexTokenizer_Destroy_IMP(RegexTokenizer *self) {
+    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
+    DECREF(ivars->pattern);
+    pcre *re = (pcre*)ivars->token_re;
+    if (re) {
+        pcre_free(re);
+    }
+    SUPER_DESTROY(self, REGEXTOKENIZER);
+}
+
+void
+RegexTokenizer_Tokenize_Utf8_IMP(RegexTokenizer *self, const char *string,
+                                 size_t string_len, Inversion *inversion) {
+    RegexTokenizerIVARS *const ivars = RegexTokenizer_IVARS(self);
+    pcre      *re          = (pcre*)ivars->token_re;
+    int        byte_offset = 0;
+    uint32_t   cp_offset   = 0; // Code points
+    int        options     = PCRE_NO_UTF8_CHECK;
+    int        ovector[3];
+
+    int return_code = pcre_exec(re, NULL, string, string_len, byte_offset,
+                                options, ovector, 3);
+    while (return_code >= 0) {
+        const char *match     = string + ovector[0];
+        size_t      match_len = ovector[1] - ovector[0];
+
+        uint32_t cp_before  = S_count_code_points(string + byte_offset,
+                                                  ovector[0] - byte_offset);
+        uint32_t cp_start   = cp_offset + cp_before;
+        uint32_t cp_matched = S_count_code_points(match, match_len);
+        uint32_t cp_end     = cp_start + cp_matched;
+
+        // Add a token to the new inversion.
+        Token *token = Token_new(match, match_len, cp_start, cp_end, 1.0f, 1);
+        Inversion_Append(inversion, token);
+
+        byte_offset = ovector[1];
+        cp_offset   = cp_end;
+        return_code = pcre_exec(re, NULL, string, string_len, byte_offset,
+                                options, ovector, 3);
+    }
+
+    if (return_code != PCRE_ERROR_NOMATCH) {
+        THROW(ERR, "pcre_exec failed: %d", return_code);
+    }
+}
+
+static uint32_t
+S_count_code_points(const char *string, size_t len) {
+    uint32_t num_code_points = 0;
+    size_t i = 0;
+
+    while (i < len) {
+        i += StrHelp_UTF8_COUNT[(uint8_t)(string[i])];
+        ++num_code_points;
+    }
+
+    if (i != len) {
+        THROW(ERR, "Match between code point boundaries in '%s'", string);
+    }
+
+    return num_code_points;
+}
+
+#else // CHY_HAS_PCRE_H
+
+bool
+RegexTokenizer_is_available(void) {
+    return false;
+}
+
+RegexTokenizer*
+RegexTokenizer_init(RegexTokenizer *self, String *pattern) {
+    UNUSED_VAR(self);
+    UNUSED_VAR(pattern);
+    THROW(ERR,
+          "RegexTokenizer is not available because Lucy was compiled"
+          " without PCRE.");
+    UNREACHABLE_RETURN(RegexTokenizer*);
+}
+
+void
+RegexTokenizer_Set_Token_RE_IMP(RegexTokenizer *self, void *token_re) {
+    UNUSED_VAR(self);
+    UNUSED_VAR(token_re);
+    THROW(ERR,
+          "RegexTokenizer is not available because Lucy was compiled"
+          " without PCRE.");
+}
+
+void
+RegexTokenizer_Destroy_IMP(RegexTokenizer *self) {
+    UNUSED_VAR(self);
+    THROW(ERR,
+          "RegexTokenizer is not available because Lucy was compiled"
+          " without PCRE.");
+}
+
+void
+RegexTokenizer_Tokenize_Utf8_IMP(RegexTokenizer *self, const char *string,
+                                 size_t string_len, Inversion *inversion) {
+    UNUSED_VAR(self);
+    UNUSED_VAR(string);
+    UNUSED_VAR(string_len);
+    UNUSED_VAR(inversion);
+    THROW(ERR,
+          "RegexTokenizer is not available because Lucy was compiled"
+          " without PCRE.");
+}
+
+#endif // CHY_HAS_PCRE_H
+
+/********************************** Doc ********************************/
+
+Doc*
+Doc_init(Doc *self, void *fields, int32_t doc_id) {
+    DocIVARS *const ivars = Doc_IVARS(self);
+    Hash *hash;
+
+    if (fields) {
+        hash = (Hash *)INCREF(CERTIFY(fields, HASH));
+    }
+    else {
+        hash = Hash_new(0);
+    }
+    ivars->fields = hash;
+    ivars->doc_id = doc_id;
+
+    return self;
+}
+
+void
+Doc_Set_Fields_IMP(Doc *self, void *fields) {
+    DocIVARS *const ivars = Doc_IVARS(self);
+    DECREF(ivars->fields);
+    ivars->fields = CERTIFY(fields, HASH);
+}
+
+uint32_t
+Doc_Get_Size_IMP(Doc *self) {
+    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
+    return Hash_Get_Size(hash);
+}
+
+void
+Doc_Store_IMP(Doc *self, String *field, Obj *value) {
+    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
+    Hash_Store(hash, field, INCREF(value));
+}
+
+void
+Doc_Serialize_IMP(Doc *self, OutStream *outstream) {
+    DocIVARS *const ivars = Doc_IVARS(self);
+    Hash *hash = (Hash*)ivars->fields;
+    Freezer_serialize_hash(hash, outstream);
+    OutStream_Write_C32(outstream, ivars->doc_id);
+}
+
+Doc*
+Doc_Deserialize_IMP(Doc *self, InStream *instream) {
+    DocIVARS *const ivars = Doc_IVARS(self);
+    ivars->fields = Freezer_read_hash(instream);
+    ivars->doc_id = InStream_Read_C32(instream);
+    return self;
+}
+
+Obj*
+Doc_Extract_IMP(Doc *self, String *field) {
+    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
+    return INCREF(Hash_Fetch(hash, field));
+}
+
+Hash*
+Doc_Dump_IMP(Doc *self) {
+    UNUSED_VAR(self);
+    THROW(ERR, "TODO");
+    UNREACHABLE_RETURN(Hash*);
+}
+
+Doc*
+Doc_Load_IMP(Doc *self, Obj *dump) {
+    UNUSED_VAR(self);
+    UNUSED_VAR(dump);
+    THROW(ERR, "TODO");
+    UNREACHABLE_RETURN(Doc*);
+}
+
+bool
+Doc_Equals_IMP(Doc *self, Obj *other) {
+    if ((Doc*)other == self)   { return true;  }
+    if (!Obj_is_a(other, DOC)) { return false; }
+    DocIVARS *const ivars = Doc_IVARS(self);
+    DocIVARS *const ovars = Doc_IVARS((Doc*)other);
+    return Hash_Equals((Hash*)ivars->fields, (Obj*)ovars->fields);
+}
+
+void
+Doc_Destroy_IMP(Doc *self) {
+    DocIVARS *const ivars = Doc_IVARS(self);
+    DECREF(ivars->fields);
+    SUPER_DESTROY(self, DOC);
+}
+
+
+/**************************** DocReader *****************************/
+
+HitDoc*
+DefDocReader_Fetch_Doc_IMP(DefaultDocReader *self, int32_t doc_id) {
+    DefaultDocReaderIVARS *const ivars = DefDocReader_IVARS(self);
+    Schema   *const schema = ivars->schema;
+    InStream *const dat_in = ivars->dat_in;
+    InStream *const ix_in  = ivars->ix_in;
+    Hash     *const fields = Hash_new(1);
+    int64_t   start;
+    uint32_t  num_fields;
+    uint32_t  field_name_cap = 31;
+    char     *field_name = (char*)MALLOCATE(field_name_cap + 1);
+
+    // Get data file pointer from index, read number of fields.
+    InStream_Seek(ix_in, (int64_t)doc_id * 8);
+    start = InStream_Read_U64(ix_in);
+    InStream_Seek(dat_in, start);
+    num_fields = InStream_Read_C32(dat_in);
+
+    // Decode stored data and build up the doc field by field.
+    while (num_fields--) {
+        uint32_t        field_name_len;
+        Obj       *value;
+        FieldType *type;
+
+        // Read field name.
+        field_name_len = InStream_Read_C32(dat_in);
+        if (field_name_len > field_name_cap) {
+            field_name_cap = field_name_len;
+            field_name     = (char*)REALLOCATE(field_name,
+                                                    field_name_cap + 1);
+        }
+        InStream_Read_Bytes(dat_in, field_name, field_name_len);
+
+        // Find the Field's FieldType.
+        String *field_name_str = SSTR_WRAP_UTF8(field_name, field_name_len);
+        type = Schema_Fetch_Type(schema, field_name_str);
+
+        // Read the field value.
+        switch (FType_Primitive_ID(type) & FType_PRIMITIVE_ID_MASK) {
+            case FType_TEXT: {
+                    uint32_t value_len = InStream_Read_C32(dat_in);
+                    char *buf = (char*)MALLOCATE(value_len + 1);
+                    InStream_Read_Bytes(dat_in, buf, value_len);
+                    buf[value_len] = '\0';
+                    value = (Obj*)Str_new_steal_utf8(buf, value_len);
+                    break;
+                }
+            case FType_BLOB: {
+                    uint32_t value_len = InStream_Read_C32(dat_in);
+                    char *buf = (char*)MALLOCATE(value_len);
+                    InStream_Read_Bytes(dat_in, buf, value_len);
+                    value = (Obj*)Blob_new_steal(buf, value_len);
+                    break;
+                }
+            case FType_FLOAT32:
+                value = (Obj*)Float_new(InStream_Read_F32(dat_in));
+                break;
+            case FType_FLOAT64:
+                value = (Obj*)Float_new(InStream_Read_F64(dat_in));
+                break;
+            case FType_INT32:
+                value = (Obj*)Int_new((int32_t)InStream_Read_C32(dat_in));
+                break;
+            case FType_INT64:
+                value = (Obj*)Int_new((int64_t)InStream_Read_C64(dat_in));
+                break;
+            default:
+                value = NULL;
+                THROW(ERR, "Unrecognized type: %o", type);
+        }
+
+        // Store the value.
+        Hash_Store_Utf8(fields, field_name, field_name_len, value);
+    }
+    FREEMEM(field_name);
+
+    HitDoc *retval = HitDoc_new(fields, doc_id, 0.0);
+    DECREF(fields);
+    return retval;
+}
+
+/**************************** Inverter *****************************/
+
+static InverterEntry*
+S_fetch_entry(InverterIVARS *ivars, String *field) {
+    Schema *const schema = ivars->schema;
+    int32_t field_num = Seg_Field_Num(ivars->segment, field);
+    if (!field_num) {
+        // This field seems not to be in the segment yet.  Try to find it in
+        // the Schema.
+        if (Schema_Fetch_Type(schema, field)) {
+            // The field is in the Schema.  Get a field num from the Segment.
+            field_num = Seg_Add_Field(ivars->segment, field);
+        }
+        else {
+            // We've truly failed to find the field.  The user must
+            // not have spec'd it.
+            THROW(ERR, "Unknown field name: '%o'", field);
+        }
+    }
+
+    InverterEntry *entry
+        = (InverterEntry*)Vec_Fetch(ivars->entry_pool, field_num);
+    if (!entry) {
+        entry = InvEntry_new(schema, (String*)field, field_num);
+        Vec_Store(ivars->entry_pool, field_num, (Obj*)entry);
+    }
+    return entry;
+}
+
+void
+Inverter_Invert_Doc_IMP(Inverter *self, Doc *doc) {
+    InverterIVARS *const ivars = Inverter_IVARS(self);
+    Hash *const fields = (Hash*)Doc_Get_Fields(doc);
+
+    // Prepare for the new doc.
+    Inverter_Set_Doc(self, doc);
+
+    // Extract and invert the doc's fields.
+    HashIterator *iter = HashIter_new(fields);
+    while (HashIter_Next(iter)) {
+        String *field = HashIter_Get_Key(iter);
+        Obj    *obj   = HashIter_Get_Value(iter);
+
+        InverterEntry *inventry = S_fetch_entry(ivars, field);
+        InverterEntryIVARS *inventry_ivars = InvEntry_IVARS(inventry);
+        FieldType *type = inventry_ivars->type;
+
+        // Get the field value.
+        switch (FType_Primitive_ID(type) & FType_PRIMITIVE_ID_MASK) {
+            case FType_TEXT: {
+                    CERTIFY(obj, STRING);
+                    break;
+                }
+            case FType_BLOB: {
+                    CERTIFY(obj, BLOB);
+                    break;
+                }
+            case FType_INT32:
+            case FType_INT64: {
+                    CERTIFY(obj, INTEGER);
+                    break;
+                }
+            case FType_FLOAT32:
+            case FType_FLOAT64: {
+                    CERTIFY(obj, FLOAT);
+                    break;
+                }
+            default:
+                THROW(ERR, "Unrecognized type: %o", type);
+        }
+
+        if (inventry_ivars->value != obj) {
+            DECREF(inventry_ivars->value);
+            inventry_ivars->value = INCREF(obj);
+        }
+
+        Inverter_Add_Field(self, inventry);
+    }
+    DECREF(iter);
+}
+
+

--- a/go/cfext/lucy.c
+++ b/go/cfext/lucy.c
@@ -86,61 +86,53 @@ RegexTokenizer_Tokenize_Utf8_IMP(RegexTokenizer *self, const char *string,
 /********************************** Doc ********************************/
 
 Doc*
+(*GOLUCY_Doc_init_BRIDGE)(Doc *self, void *fields, int32_t doc_id);
+
+Doc*
 Doc_init(Doc *self, void *fields, int32_t doc_id) {
-    DocIVARS *const ivars = Doc_IVARS(self);
-    Hash *hash;
-
-    if (fields) {
-        hash = (Hash *)INCREF(CERTIFY(fields, HASH));
-    }
-    else {
-        hash = Hash_new(0);
-    }
-    ivars->fields = hash;
-    ivars->doc_id = doc_id;
-
-    return self;
+    return GOLUCY_Doc_init_BRIDGE(self, fields, doc_id);
 }
+
+Doc_Set_Fields_t GOLUCY_Doc_Set_Fields_BRIDGE;
 
 void
 Doc_Set_Fields_IMP(Doc *self, void *fields) {
-    DocIVARS *const ivars = Doc_IVARS(self);
-    DECREF(ivars->fields);
-    ivars->fields = CERTIFY(fields, HASH);
+    GOLUCY_Doc_Set_Fields_BRIDGE(self, fields);
 }
+
+Doc_Get_Size_t GOLUCY_Doc_Get_Size_BRIDGE;
 
 uint32_t
 Doc_Get_Size_IMP(Doc *self) {
-    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
-    return Hash_Get_Size(hash);
+    return GOLUCY_Doc_Get_Size_BRIDGE(self);
 }
+
+Doc_Store_t GOLUCY_Doc_Store_BRIDGE;
 
 void
 Doc_Store_IMP(Doc *self, String *field, Obj *value) {
-    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
-    Hash_Store(hash, field, INCREF(value));
+    GOLUCY_Doc_Store_BRIDGE(self, field, value);
 }
+
+Doc_Serialize_t GOLUCY_Doc_Serialize_BRIDGE;
 
 void
 Doc_Serialize_IMP(Doc *self, OutStream *outstream) {
-    DocIVARS *const ivars = Doc_IVARS(self);
-    Hash *hash = (Hash*)ivars->fields;
-    Freezer_serialize_hash(hash, outstream);
-    OutStream_Write_C32(outstream, ivars->doc_id);
+    GOLUCY_Doc_Serialize_BRIDGE(self, outstream);
 }
+
+Doc_Deserialize_t GOLUCY_Doc_Deserialize_BRIDGE;
 
 Doc*
 Doc_Deserialize_IMP(Doc *self, InStream *instream) {
-    DocIVARS *const ivars = Doc_IVARS(self);
-    ivars->fields = Freezer_read_hash(instream);
-    ivars->doc_id = InStream_Read_C32(instream);
-    return self;
+    return GOLUCY_Doc_Deserialize_BRIDGE(self, instream);
 }
+
+Doc_Extract_t GOLUCY_Doc_Extract_BRIDGE;
 
 Obj*
 Doc_Extract_IMP(Doc *self, String *field) {
-    Hash *hash = (Hash*)Doc_IVARS(self)->fields;
-    return INCREF(Hash_Fetch(hash, field));
+    return GOLUCY_Doc_Extract_BRIDGE(self, field);
 }
 
 Hash*
@@ -158,22 +150,19 @@ Doc_Load_IMP(Doc *self, Obj *dump) {
     UNREACHABLE_RETURN(Doc*);
 }
 
+Doc_Equals_t GOLUCY_Doc_Equals_BRIDGE;
+
 bool
 Doc_Equals_IMP(Doc *self, Obj *other) {
-    if ((Doc*)other == self)   { return true;  }
-    if (!Obj_is_a(other, DOC)) { return false; }
-    DocIVARS *const ivars = Doc_IVARS(self);
-    DocIVARS *const ovars = Doc_IVARS((Doc*)other);
-    return Hash_Equals((Hash*)ivars->fields, (Obj*)ovars->fields);
+    return GOLUCY_Doc_Equals_BRIDGE(self, other);
 }
+
+Doc_Destroy_t GOLUCY_Doc_Destroy_BRIDGE;
 
 void
 Doc_Destroy_IMP(Doc *self) {
-    DocIVARS *const ivars = Doc_IVARS(self);
-    DECREF(ivars->fields);
-    SUPER_DESTROY(self, DOC);
+    GOLUCY_Doc_Destroy_BRIDGE(self);
 }
-
 
 /**************************** DocReader *****************************/
 

--- a/go/lucy/lucy.go
+++ b/go/lucy/lucy.go
@@ -17,10 +17,17 @@
 package lucy
 
 /*
+#define C_LUCY_DOC
 #define C_LUCY_REGEXTOKENIZER
 
 #include "lucy_parcel.h"
 #include "Lucy/Analysis/RegexTokenizer.h"
+#include "Lucy/Document/Doc.h"
+
+#include "Clownfish/Hash.h"
+#include "Lucy/Store/InStream.h"
+#include "Lucy/Store/OutStream.h"
+#include "Lucy/Util/Freezer.h"
 
 extern lucy_RegexTokenizer*
 GOLUCY_RegexTokenizer_init(lucy_RegexTokenizer *self, cfish_String *pattern);
@@ -38,6 +45,44 @@ extern void
 (*GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE)(lucy_RegexTokenizer *self, const char *str,
 											  size_t string_len, lucy_Inversion *inversion);
 
+extern lucy_Doc*
+GOLUCY_Doc_init(lucy_Doc *doc, void *fields, int32_t doc_id);
+extern lucy_Doc*
+(*GOLUCY_Doc_init_BRIDGE)(lucy_Doc *doc, void *fields, int32_t doc_id);
+extern void
+GOLUCY_Doc_Set_Fields(lucy_Doc *self, void *fields);
+extern void
+(*GOLUCY_Doc_Set_Fields_BRIDGE)(lucy_Doc *self, void *fields);
+extern uint32_t
+GOLUCY_Doc_Get_Size(lucy_Doc *self);
+extern uint32_t
+(*GOLUCY_Doc_Get_Size_BRIDGE)(lucy_Doc *self);
+extern void
+GOLUCY_Doc_Store(lucy_Doc *self, cfish_String *field, cfish_Obj *value);
+extern void
+(*GOLUCY_Doc_Store_BRIDGE)(lucy_Doc *self, cfish_String *field, cfish_Obj *value);
+extern void
+GOLUCY_Doc_Serialize(lucy_Doc *self, lucy_OutStream *outstream);
+extern void
+(*GOLUCY_Doc_Serialize_BRIDGE)(lucy_Doc *self, lucy_OutStream *outstream);
+extern lucy_Doc*
+GOLUCY_Doc_Deserialize(lucy_Doc *self, lucy_InStream *instream);
+extern lucy_Doc*
+(*GOLUCY_Doc_Deserialize_BRIDGE)(lucy_Doc *self, lucy_InStream *instream);
+extern cfish_Obj*
+GOLUCY_Doc_Extract(lucy_Doc *self, cfish_String *field);
+extern cfish_Obj*
+(*GOLUCY_Doc_Extract_BRIDGE)(lucy_Doc *self, cfish_String *field);
+extern bool
+GOLUCY_Doc_Equals(lucy_Doc *self, cfish_Obj *other);
+extern bool
+(*GOLUCY_Doc_Equals_BRIDGE)(lucy_Doc *self, cfish_Obj *other);
+extern void
+GOLUCY_Doc_Destroy(lucy_Doc *self);
+extern void
+(*GOLUCY_Doc_Destroy_BRIDGE)(lucy_Doc *self);
+
+
 
 // C symbols linked into a Go-built package archive are not visible to
 // external C code -- but internal code *can* see symbols from outside.
@@ -49,10 +94,20 @@ GOLUCY_glue_exported_symbols() {
 	GOLUCY_RegexTokenizer_Destroy_BRIDGE = GOLUCY_RegexTokenizer_Destroy;
 	GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE
 		= (LUCY_RegexTokenizer_Tokenize_Utf8_t)GOLUCY_RegexTokenizer_Tokenize_Utf8;
+	GOLUCY_Doc_init_BRIDGE = GOLUCY_Doc_init;
+	GOLUCY_Doc_Set_Fields_BRIDGE = GOLUCY_Doc_Set_Fields;
+	GOLUCY_Doc_Get_Size_BRIDGE = GOLUCY_Doc_Get_Size;
+	GOLUCY_Doc_Store_BRIDGE = GOLUCY_Doc_Store;
+	GOLUCY_Doc_Serialize_BRIDGE = GOLUCY_Doc_Serialize;
+	GOLUCY_Doc_Deserialize_BRIDGE = GOLUCY_Doc_Deserialize;
+	GOLUCY_Doc_Extract_BRIDGE = GOLUCY_Doc_Extract;
+	GOLUCY_Doc_Equals_BRIDGE = GOLUCY_Doc_Equals;
+	GOLUCY_Doc_Destroy_BRIDGE = GOLUCY_Doc_Destroy;
 }
 
 */
 import "C"
+import "unsafe"
 import _ "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
 
 func init() {
@@ -72,4 +127,90 @@ func GOLUCY_RegexTokenizer_Destroy(rt *C.lucy_RegexTokenizer) {
 //export GOLUCY_RegexTokenizer_Tokenize_Utf8
 func GOLUCY_RegexTokenizer_Tokenize_Utf8(rt *C.lucy_RegexTokenizer, str *C.char,
 	stringLen C.size_t, inversion *C.lucy_Inversion) {
+}
+
+func NewDoc(docID int32) Doc {
+	retvalCF := C.lucy_Doc_new(nil, C.int32_t(docID))
+	return WRAPDoc(unsafe.Pointer(retvalCF))
+}
+
+//export GOLUCY_Doc_init
+func GOLUCY_Doc_init(d *C.lucy_Doc, fields unsafe.Pointer, docID C.int32_t) *C.lucy_Doc {
+	ivars := C.lucy_Doc_IVARS(d)
+	if fields != nil {
+		ivars.fields = unsafe.Pointer(C.cfish_inc_refcount(fields))
+	} else {
+		ivars.fields = unsafe.Pointer(C.cfish_Hash_new(0))
+	}
+	ivars.doc_id = docID
+	return d
+}
+
+//export GOLUCY_Doc_Set_Fields
+func GOLUCY_Doc_Set_Fields(d *C.lucy_Doc, fields unsafe.Pointer) {
+	ivars := C.lucy_Doc_IVARS(d)
+	temp := ivars.fields
+	ivars.fields = unsafe.Pointer(C.cfish_inc_refcount(fields))
+	C.cfish_decref(temp)
+}
+
+//export GOLUCY_Doc_Get_Size
+func GOLUCY_Doc_Get_Size(d *C.lucy_Doc) C.uint32_t {
+	ivars := C.lucy_Doc_IVARS(d)
+	hash := ((*C.cfish_Hash)(ivars.fields))
+	return C.uint32_t(C.CFISH_Hash_Get_Size(hash))
+}
+
+//export GOLUCY_Doc_Store
+func GOLUCY_Doc_Store(d *C.lucy_Doc, field *C.cfish_String, value *C.cfish_Obj) {
+	ivars := C.lucy_Doc_IVARS(d)
+	hash := (*C.cfish_Hash)(ivars.fields)
+	C.CFISH_Hash_Store(hash, field, C.cfish_inc_refcount(unsafe.Pointer(value)))
+}
+
+//export GOLUCY_Doc_Serialize
+func GOLUCY_Doc_Serialize(d *C.lucy_Doc, outstream *C.lucy_OutStream) {
+	ivars := C.lucy_Doc_IVARS(d)
+	hash := (*C.cfish_Hash)(ivars.fields)
+	C.lucy_Freezer_serialize_hash(hash, outstream)
+	C.LUCY_OutStream_Write_C32(outstream, C.uint32_t(ivars.doc_id))
+}
+
+//export GOLUCY_Doc_Deserialize
+func GOLUCY_Doc_Deserialize(d *C.lucy_Doc, instream *C.lucy_InStream) *C.lucy_Doc {
+	ivars := C.lucy_Doc_IVARS(d)
+	ivars.fields = unsafe.Pointer(C.lucy_Freezer_read_hash(instream))
+	ivars.doc_id = C.int32_t(C.LUCY_InStream_Read_C32(instream))
+	return d
+}
+
+//export GOLUCY_Doc_Extract
+func GOLUCY_Doc_Extract(d *C.lucy_Doc, field *C.cfish_String) *C.cfish_Obj {
+	ivars := C.lucy_Doc_IVARS(d)
+	hash := (*C.cfish_Hash)(ivars.fields)
+	val := C.CFISH_Hash_Fetch(hash, field)
+	return C.cfish_inc_refcount(unsafe.Pointer(val))
+}
+
+//export GOLUCY_Doc_Equals
+func GOLUCY_Doc_Equals(d *C.lucy_Doc, other *C.cfish_Obj) C.bool {
+	twin := (*C.lucy_Doc)(unsafe.Pointer(other))
+	if twin == d {
+		return true
+	}
+	if !C.cfish_Obj_is_a(other, C.LUCY_DOC) {
+		return false
+	}
+	ivars := C.lucy_Doc_IVARS(d)
+	ovars := C.lucy_Doc_IVARS(twin)
+	hash := (*C.cfish_Hash)(ivars.fields)
+	otherHash := (*C.cfish_Obj)(ovars.fields)
+	return C.CFISH_Hash_Equals(hash, otherHash)
+}
+
+//export GOLUCY_Doc_Destroy
+func GOLUCY_Doc_Destroy(d *C.lucy_Doc) {
+	ivars := C.lucy_Doc_IVARS(d)
+	C.cfish_decref(unsafe.Pointer(ivars.fields))
+	C.cfish_super_destroy(unsafe.Pointer(d), C.LUCY_DOC)
 }

--- a/go/lucy/lucy.go
+++ b/go/lucy/lucy.go
@@ -17,11 +17,59 @@
 package lucy
 
 /*
+#define C_LUCY_REGEXTOKENIZER
+
 #include "lucy_parcel.h"
+#include "Lucy/Analysis/RegexTokenizer.h"
+
+extern lucy_RegexTokenizer*
+GOLUCY_RegexTokenizer_init(lucy_RegexTokenizer *self, cfish_String *pattern);
+extern lucy_RegexTokenizer*
+(*GOLUCY_RegexTokenizer_init_BRIDGE)(lucy_RegexTokenizer *self,
+									 cfish_String *pattern);
+extern void
+GOLUCY_RegexTokenizer_Destroy(lucy_RegexTokenizer *self);
+extern void
+(*GOLUCY_RegexTokenizer_Destroy_BRIDGE)(lucy_RegexTokenizer *self);
+extern void
+GOLUCY_RegexTokenizer_Tokenize_Utf8(lucy_RegexTokenizer *self, char *str,
+									size_t string_len, lucy_Inversion *inversion);
+extern void
+(*GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE)(lucy_RegexTokenizer *self, const char *str,
+											  size_t string_len, lucy_Inversion *inversion);
+
+
+// C symbols linked into a Go-built package archive are not visible to
+// external C code -- but internal code *can* see symbols from outside.
+// This allows us to fake up symbol export by assigning values only known
+// interally to external symbols during Go package initialization.
+static CFISH_INLINE void
+GOLUCY_glue_exported_symbols() {
+	GOLUCY_RegexTokenizer_init_BRIDGE = GOLUCY_RegexTokenizer_init;
+	GOLUCY_RegexTokenizer_Destroy_BRIDGE = GOLUCY_RegexTokenizer_Destroy;
+	GOLUCY_RegexTokenizer_Tokenize_Utf8_BRIDGE
+		= (LUCY_RegexTokenizer_Tokenize_Utf8_t)GOLUCY_RegexTokenizer_Tokenize_Utf8;
+}
+
 */
 import "C"
 import _ "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
 
 func init() {
+	C.GOLUCY_glue_exported_symbols()
 	C.lucy_bootstrap_parcel()
+}
+
+//export GOLUCY_RegexTokenizer_init
+func GOLUCY_RegexTokenizer_init(rt *C.lucy_RegexTokenizer, pattern *C.cfish_String) *C.lucy_RegexTokenizer {
+	return nil
+}
+
+//export GOLUCY_RegexTokenizer_Destroy
+func GOLUCY_RegexTokenizer_Destroy(rt *C.lucy_RegexTokenizer) {
+}
+
+//export GOLUCY_RegexTokenizer_Tokenize_Utf8
+func GOLUCY_RegexTokenizer_Tokenize_Utf8(rt *C.lucy_RegexTokenizer, str *C.char,
+	stringLen C.size_t, inversion *C.lucy_Inversion) {
 }

--- a/go/lucy/lucy_test.go
+++ b/go/lucy/lucy_test.go
@@ -18,6 +18,7 @@ package lucy
 
 import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
 import "testing"
+import "reflect"
 
 func TestStuff(t *testing.T) {
 	NewSchema()
@@ -27,5 +28,14 @@ func TestOpenIndexer(t *testing.T) {
 	_, err := OpenIndexer(&OpenIndexerArgs{Index: "notalucyindex"})
 	if _, ok := err.(clownfish.Err); !ok {
 		t.Error("Didn't catch exception opening indexer")
+	}
+}
+
+func TestRegex(t *testing.T) {
+	tokenizer := NewRegexTokenizer("\\S+")
+	var expected []interface{} = []interface{}{"foo", "bar", "baz"}
+	got := tokenizer.Split("foo bar baz")
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected %v, got %v", expected, got)
 	}
 }

--- a/go/lucy/registry.go
+++ b/go/lucy/registry.go
@@ -1,0 +1,135 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "sync"
+
+type indexInt uintptr
+
+type objRegistry struct {
+	// Use pointer to array to guarantee atomic update for lock-free reads.
+	// Assume that loads and stores of the pointer are atomic.
+	entries *[]interface{}
+	freeListHead indexInt
+	mutex sync.Mutex
+}
+
+func newObjRegistry(size uintptr) *objRegistry {
+	entries := make([]interface{}, size)
+
+	// Each empty entry points to the index of the next empty entry.  Index 0
+	// is unused.  The last slot is seet to a terminating sentry value of 0.
+	entries[0] = indexInt(0) // unused
+	for i := uintptr(1); i < size - 1; i++ {
+		entries[i] = indexInt(i + 1)
+	}
+	entries[size-1] = indexInt(0)
+
+	reg := &objRegistry{}
+	reg.entries = &entries
+	reg.freeListHead = indexInt(1)
+
+	return reg
+}
+
+func (reg *objRegistry) store(obj interface{}) uintptr {
+	reg.mutex.Lock()
+
+	// Find the index of the next empty slot.
+	index := uintptr(reg.freeListHead)
+
+	entries := reg.entries
+
+	if (index != 0) {
+		// A slot is available.  It contains the index of the next available
+		// slot; put that index into the freeListHead.
+		reg.freeListHead = (*entries)[index].(indexInt)
+	} else {
+		// The sentinel value was encountered, indicating that we are out of
+		// space and must grow the entries array.
+
+		// The list head was 0, a slot we don't want to use.  Figure out what
+		// slot we're going to use instead.  If the current size of the
+		// entries array is 8, and will soon be 16, use slot 8.
+		index = uintptr(len(*entries))
+
+		// Duplicate the array and copy in the existing entries data.
+		newSize := index * 2
+		newEntries := make([]interface{}, newSize)
+		copy(newEntries, *entries)
+
+		// Set up each new empty slot to point at another new empty slot, up
+		// to the final slot which will get the sentinel value 0.
+		for i := index + 1; i < newSize - 1; i++ {
+			newEntries[i] = indexInt(i + 1)
+		}
+		newEntries[newSize - 1] = indexInt(0)
+		entries = &newEntries
+		reg.entries = entries
+
+		// Set the freeListHead to one greater than the slot we're using this
+		// time -- i.e. if the current size is 8, the new size is 16, and the
+		// slot we use for the supplied value is 8, then the new list head
+		// will be 9.
+		reg.freeListHead = indexInt(index + 1)
+	}
+
+	// Store the supplied value in the slot.
+	(*entries)[index] = obj
+
+	reg.mutex.Unlock()
+
+	return index
+}
+
+func (reg *objRegistry) fetch(index uintptr) interface{} {
+
+	// Ignore an out of range request.
+	if index >= uintptr(len(*reg.entries)) {
+		return nil
+	}
+	entry := (*reg.entries)[index]
+	if _, ok := entry.(indexInt); ok {
+		// Return nil if the slot is empty.
+		return nil
+	}
+	return entry
+}
+
+func (reg *objRegistry) delete(index uintptr) {
+	reg.mutex.Lock()
+
+	// Overwrite the value at the supplied index with the freeListHead.  For
+	// example, if you are storing strings and the entries array consists of
+	// {0, "A", "B", C", 5, 6, 7, 0}, with freeListHead at 4, then deleting
+	// index 2 (string value "B") will result in the following state:
+	// {0, "A", 4, "C", 5, 6, 7, 0} and freeListHead at 2.
+	//
+	// Some potential errors are ignored:
+	// *   Index is greater than the size of the array.
+	// *   Slot is empty.
+	if index < uintptr(len(*reg.entries)) {
+		_, isIndexInt := (*reg.entries)[index].(indexInt)
+		if !isIndexInt {
+			(*reg.entries)[index] = reg.freeListHead
+			reg.freeListHead = indexInt(index)
+		}
+	}
+
+	reg.mutex.Unlock()
+}
+

--- a/go/lucy/registry_test.go
+++ b/go/lucy/registry_test.go
@@ -1,0 +1,84 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "testing"
+import "math/rand"
+
+func TestRegistrySingle(t *testing.T) {
+	reg := newObjRegistry(4)
+	index := reg.store(42)
+	if intVal, ok := reg.fetch(index).(int); !ok || intVal != 42 {
+		t.Error("Failed to store/fetch int")
+	}
+	reg.delete(index)
+	if reg.fetch(index) != nil {
+		t.Error("Failed to delete int")
+	}
+}
+
+func TestRegistryMany(t *testing.T) {
+	reg := newObjRegistry(4)
+	stored := make(map[int]uintptr)
+	deleted := make(map[int]uintptr)
+	for i := 0; i < 1000; i++ {
+		if rand.Intn(10) == 0 {
+			// Randomly delete an element 10% of the time.
+			goner := rand.Intn(i - 1)
+			if index, ok := stored[goner]; ok {
+				reg.delete(index)
+				delete(stored, goner)
+				deleted[goner] = index
+			}
+		}
+		stored[i] = reg.store(i)
+	}
+	for expected, index := range stored {
+		got, ok := reg.fetch(index).(int)
+		if !ok {
+			t.Errorf("Failed to fetch stored value %d at index %d", expected, index)
+		} else if got != expected {
+			t.Errorf("Expected %d got %d", expected, got)
+		}
+	}
+	for i := 0; i < len(*reg.entries) - 1; i++ {
+		got, ok := reg.fetch(uintptr(i)).(int)
+		if ok {
+			if _, wasDeleted := deleted[got]; wasDeleted {
+				t.Errorf("Deleted item %d still present at index %d", got, i)
+			}
+		}
+	}
+}
+
+func TestRegistryStringSlice(t *testing.T) {
+	reg := newObjRegistry(4)
+	s := make([]int, 2)
+	index := reg.store(&s)
+	s2 := reg.fetch(index).(*[]int)
+	(*s2)[1] = 1000
+	if s[1] != 1000 {
+		t.Error("Not the same slice")
+	}
+}
+
+func TestRegistryRange(t *testing.T) {
+	reg := newObjRegistry(4)
+	if reg.fetch(uintptr(10)) != nil {
+		t.Error("Out of range index should return nil")
+	}
+}


### PR DESCRIPTION
Port host-specific implementation code to Go/CGO instead of wrapping the C bindings.

RegexTokenizer now uses the Go `regexp` package instead of requiring pcre.  It references `regexp` objects from C using a variant on the Nick Wellnhofer's object registry code.