### PR TITLE
Generate Perl POD from public methods

### DIFF
--- a/core/Lucy/Analysis/Analyzer.cfh
+++ b/core/Lucy/Analysis/Analyzer.cfh
@@ -32,6 +32,8 @@ public abstract class Lucy::Analysis::Analyzer inherits Clownfish::Obj {
     /** Take a single [](cfish:Inversion) as input
      * and returns an Inversion, either the same one (presumably transformed
      * in some way), or a new one.
+     *
+     * @param inversion An inversion.
      */
     public abstract incremented Inversion*
     Transform(Analyzer *self, Inversion *inversion);
@@ -40,18 +42,41 @@ public abstract class Lucy::Analysis::Analyzer inherits Clownfish::Obj {
      * The default implementation simply creates an initial Inversion with a
      * single Token, then calls [](cfish:.Transform), but occasionally subclasses will
      * provide an optimized implementation which minimizes string copies.
+     *
+     * @param text A string.
      */
     public incremented Inversion*
     Transform_Text(Analyzer *self, String *text);
 
     /** Analyze text and return an array of token texts.
+     *
+     * @param text A string.
      */
     public incremented Vector*
     Split(Analyzer *self, String *text);
 
+    /** Dump the analyzer as hash.
+     *
+     * Subclasses should call [](.Dump) on the superclass. The returned
+     * object is a hash which should be populated with parameters of
+     * the analyzer.
+     *
+     * @return A hash containing a description of the analyzer.
+     */
     public incremented Obj*
     Dump(Analyzer *self);
 
+    /** Reconstruct an analyzer from a dump.
+     *
+     * Subclasses should first call [](.Load) on the superclass. The
+     * returned object is an analyzer which should be reconstructed by
+     * setting the dumped parameters from the hash contained in `dump`.
+     *
+     * Note that the invocant analyzer is unused.
+     *
+     * @param dump A hash.
+     * @return An analyzer.
+     */
     public incremented Obj*
     Load(Analyzer *self, Obj *dump);
 }

--- a/core/Lucy/Analysis/Inversion.cfh
+++ b/core/Lucy/Analysis/Inversion.cfh
@@ -33,27 +33,28 @@ public class Lucy::Analysis::Inversion inherits Clownfish::Obj {
     uint32_t   cluster_counts_size;   /* num unique texts */
 
     /**
-     * @param seed An initial Token to start things off, which may be NULL.
+     * @param seed An initial Token to start things off, which may be
+     * [](@null).
      */
-    inert incremented Inversion*
+    public inert incremented Inversion*
     new(Token *seed = NULL);
 
     /** Tack a token onto the end of the Inversion.
      *
      * @param token A Token.
      */
-    void
+    public void
     Append(Inversion *self, decremented Token *token);
 
     /** Return the next token in the Inversion until out of tokens.
      */
-    nullable Token*
+    public nullable Token*
     Next(Inversion *self);
 
     /** Reset the Inversion's iterator, so that the next call to next()
      * returns the first Token in the inversion.
      */
-    void
+    public void
     Reset(Inversion *self);
 
     /** Assign positions to constituent Tokens, tallying up the position

--- a/core/Lucy/Analysis/Token.cfh
+++ b/core/Lucy/Analysis/Token.cfh
@@ -38,8 +38,7 @@ parcel Lucy;
  * `boost` is a per-token weight.  Use this when you want to assign
  * more or less importance to a particular token, as you might for emboldened
  * text within an HTML document, for example.  (Note: The field this token
- * belongs to must be spec'd to use a posting of type
- * [](cfish:RichPosting).)
+ * belongs to must be spec'd to use a posting of type RichPosting.)
  *
  * `pos_inc` is the POSition INCrement, measured in Tokens.  This
  * attribute, which defaults to 1, is a an advanced tool for manipulating
@@ -49,7 +48,7 @@ parcel Lucy;
  * will end up assigned to positions 0, 1, and 1001 -- and will no longer
  * produce a phrase match for the query `"three blind mice"`.
  */
-class Lucy::Analysis::Token inherits Clownfish::Obj {
+public class Lucy::Analysis::Token inherits Clownfish::Obj {
 
     char     *text;
     size_t    len;
@@ -59,11 +58,21 @@ class Lucy::Analysis::Token inherits Clownfish::Obj {
     int32_t   pos_inc;
     int32_t   pos;
 
-    inert incremented Token*
+    public inert incremented Token*
     new(const char *text, size_t len, uint32_t start_offset,
         uint32_t end_offset, float boost = 1.0, int32_t pos_inc = 1);
 
-    inert Token*
+    /**
+     * @param text A UTF-8 string.
+     * @param len Size of the string in bytes.
+     * @param start_offset Start offset into the original document in Unicode
+     * code points.
+     * @param start_offset End offset into the original document in Unicode
+     * code points.
+     * @param boost Per-token weight.
+     * @param pos_inc Position increment for phrase matching.
+     */
+    public inert Token*
     init(Token *self, const char *text, size_t len,
          uint32_t start_offset, uint32_t end_offset,
          float boost = 1.0, int32_t pos_inc = 1);
@@ -73,16 +82,16 @@ class Lucy::Analysis::Token inherits Clownfish::Obj {
     inert int
     compare(const void *va, const void *vb);
 
-    uint32_t
+    public uint32_t
     Get_Start_Offset(Token *self);
 
-    uint32_t
+    public uint32_t
     Get_End_Offset(Token *self);
 
-    float
+    public float
     Get_Boost(Token *self);
 
-    int32_t
+    public int32_t
     Get_Pos_Inc(Token *self);
 
     /** Accessor for pos.  Only valid after position increments for an array
@@ -91,13 +100,13 @@ class Lucy::Analysis::Token inherits Clownfish::Obj {
     int32_t
     Get_Pos(Token *self);
 
-    char*
+    public char*
     Get_Text(Token *self);
 
-    size_t
+    public size_t
     Get_Len(Token *self);
 
-    void
+    public void
     Set_Text(Token *self, char *text, size_t len);
 
     public void

--- a/core/Lucy/Docs/IRTheory.md
+++ b/core/Lucy/Docs/IRTheory.md
@@ -19,10 +19,10 @@ formal introduction:
 Since Lucy is a practical implementation of IR theory, it loads these
 abstract, distilled definitions down with useful traits.  For instance, a
 "posting" in its most rarefied form is simply a term-document pairing; in
-Lucy, the class [](cfish:lucy.MatchPosting) fills this
+Lucy, the class MatchPosting fills this
 role.  However, by associating additional information with a posting like the
 number of times the term occurs in the document, we can turn it into a
-[](cfish:lucy.ScorePosting), making it possible
+ScorePosting, making it possible
 to rank documents by relevance rather than just list documents which happen to
 match in no particular order.
 

--- a/core/Lucy/Document/Doc.cfh
+++ b/core/Lucy/Document/Doc.cfh
@@ -86,10 +86,10 @@ public class Lucy::Document::Doc inherits Clownfish::Obj {
     public bool
     Equals(Doc *self, Obj *other);
 
-    public void
+    void
     Serialize(Doc *self, OutStream *outstream);
 
-    public incremented Doc*
+    incremented Doc*
     Deserialize(decremented Doc *self, InStream *instream);
 
     public incremented Hash*

--- a/core/Lucy/Document/Doc.cfh
+++ b/core/Lucy/Document/Doc.cfh
@@ -49,8 +49,11 @@ public class Lucy::Document::Doc inherits Clownfish::Obj {
     Get_Doc_ID(Doc *self);
 
     /** Store a field value in the Doc.
+     *
+     * @param field The field name
+     * @param value The value
      */
-    void
+    public void
     Store(Doc *self, String *field, Obj *value);
 
     /** Set the doc's field's attribute.
@@ -68,17 +71,14 @@ public class Lucy::Document::Doc inherits Clownfish::Obj {
     public uint32_t
     Get_Size(Doc *self);
 
-    /** Retrieve the field's value, or NULL if the field is not present.  If
-     * the field is a text type, assign it to `target`.  Otherwise,
-     * return the interior object.  Callers must check to verify the kind of
-     * object returned.
+    /** Retrieve the field's value, or NULL if the field is not present.
      */
-    nullable incremented Obj*
+    public nullable incremented Obj*
     Extract(Doc *self, String *field);
 
     /** Return a list of names of all fields present.
      */
-    incremented Vector*
+    public incremented Vector*
     Field_Names(Doc *self);
 
     /* Unimplemented methods.
@@ -92,10 +92,10 @@ public class Lucy::Document::Doc inherits Clownfish::Obj {
     incremented Doc*
     Deserialize(decremented Doc *self, InStream *instream);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(Doc *self);
 
-    public incremented Doc*
+    incremented Doc*
     Load(Doc *self, Obj *dump);
 
     public void

--- a/core/Lucy/Document/HitDoc.cfh
+++ b/core/Lucy/Document/HitDoc.cfh
@@ -53,10 +53,10 @@ public class Lucy::Document::HitDoc inherits Lucy::Document::Doc {
     public bool
     Equals(HitDoc *self, Obj *other);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(HitDoc *self);
 
-    public incremented HitDoc*
+    incremented HitDoc*
     Load(HitDoc *self, Obj *dump);
 
     void

--- a/core/Lucy/Document/HitDoc.cfh
+++ b/core/Lucy/Document/HitDoc.cfh
@@ -59,10 +59,10 @@ public class Lucy::Document::HitDoc inherits Lucy::Document::Doc {
     public incremented HitDoc*
     Load(HitDoc *self, Obj *dump);
 
-    public void
+    void
     Serialize(HitDoc *self, OutStream *outstream);
 
-    public incremented HitDoc*
+    incremented HitDoc*
     Deserialize(decremented HitDoc *self, InStream *instream);
 }
 

--- a/core/Lucy/Index/DataReader.cfh
+++ b/core/Lucy/Index/DataReader.cfh
@@ -91,7 +91,7 @@ public class Lucy::Index::DataReader inherits Clownfish::Obj {
      * performed upon either the reader or any component subreaders other than
      * object destruction.
      */
-    public abstract void
+    abstract void
     Close(DataReader *self);
 
     public void

--- a/core/Lucy/Index/DataWriter.cfh
+++ b/core/Lucy/Index/DataWriter.cfh
@@ -53,7 +53,7 @@ public class Lucy::Index::DataWriter inherits Clownfish::Obj {
      * @param doc_id Internal number assigned to this document within the
      * segment.
      */
-    public abstract void
+    abstract void
     Add_Inverted_Doc(DataWriter *self, Inverter *inverter, int32_t doc_id);
 
     /** Add content from an existing segment into the one currently being

--- a/core/Lucy/Index/DeletionsReader.cfh
+++ b/core/Lucy/Index/DeletionsReader.cfh
@@ -59,7 +59,7 @@ class Lucy::Index::PolyDeletionsReader nickname PolyDelReader
     incremented Matcher*
     Iterator(PolyDeletionsReader *self);
 
-    public void
+    void
     Close(PolyDeletionsReader *self);
 
     public void
@@ -89,7 +89,7 @@ class Lucy::Index::DefaultDeletionsReader nickname DefDelReader
     nullable BitVector*
     Read_Deletions(DefaultDeletionsReader *self);
 
-    public void
+    void
     Close(DefaultDeletionsReader *self);
 
     public void

--- a/core/Lucy/Index/DeletionsWriter.cfh
+++ b/core/Lucy/Index/DeletionsWriter.cfh
@@ -58,7 +58,7 @@ public abstract class Lucy::Index::DeletionsWriter nickname DelWriter
 
     /** Delete the document identified in the PolyReader by the supplied id.
      */
-    public abstract void
+    abstract void
     Delete_By_Doc_ID(DeletionsWriter *self, int32_t doc_id);
 
     /** Returns true if there are updates that need to be written.
@@ -76,7 +76,7 @@ public abstract class Lucy::Index::DeletionsWriter nickname DelWriter
      * With an offset of 1000, the array in the previous example would be
      * { 1001, 0, 1002, 1003 }.
      */
-    public incremented I32Array*
+    incremented I32Array*
     Generate_Doc_Map(DeletionsWriter *self, Matcher *deletions,
                      int32_t doc_max, int32_t offset);
 
@@ -84,7 +84,7 @@ public abstract class Lucy::Index::DeletionsWriter nickname DelWriter
      * a component within the PolyReader that was supplied at
      * construction-time.
      */
-    public abstract incremented nullable Matcher*
+    abstract incremented nullable Matcher*
     Seg_Deletions(DeletionsWriter *self, SegReader *seg_reader);
 
     /** Return the number of deletions for a given segment.
@@ -130,13 +130,13 @@ class Lucy::Index::DefaultDeletionsWriter nickname DefDelWriter
     public void
     Delete_By_Query(DefaultDeletionsWriter *self, Query *query);
 
-    public void
+    void
     Delete_By_Doc_ID(DefaultDeletionsWriter *self, int32_t doc_id);
 
     public bool
     Updated(DefaultDeletionsWriter *self);
 
-    public incremented nullable Matcher*
+    incremented nullable Matcher*
     Seg_Deletions(DefaultDeletionsWriter *self, SegReader *seg_reader);
 
     public int32_t

--- a/core/Lucy/Index/DocReader.cfh
+++ b/core/Lucy/Index/DocReader.cfh
@@ -62,7 +62,7 @@ class Lucy::Index::PolyDocReader inherits Lucy::Index::DocReader {
     public incremented HitDoc*
     Fetch_Doc(PolyDocReader *self, int32_t doc_id);
 
-    public void
+    void
     Close(PolyDocReader *self);
 
     public void
@@ -92,7 +92,7 @@ class Lucy::Index::DefaultDocReader nickname DefDocReader
     void
     Read_Record(DefaultDocReader *self, ByteBuf *buffer, int32_t doc_id);
 
-    public void
+    void
     Close(DefaultDocReader *self);
 
     public void

--- a/core/Lucy/Index/DocVector.cfh
+++ b/core/Lucy/Index/DocVector.cfh
@@ -47,10 +47,10 @@ class Lucy::Index::DocVector nickname DocVec
     Blob*
     Field_Buf(DocVector *self, String *field);
 
-    public void
+    void
     Serialize(DocVector *self, OutStream *outstream);
 
-    public incremented DocVector*
+    incremented DocVector*
     Deserialize(decremented DocVector *self, InStream *instream);
 
     public void

--- a/core/Lucy/Index/DocWriter.cfh
+++ b/core/Lucy/Index/DocWriter.cfh
@@ -35,7 +35,7 @@ class Lucy::Index::DocWriter inherits Lucy::Index::DataWriter {
     init(DocWriter *self, Schema *schema, Snapshot *snapshot,
          Segment *segment, PolyReader *polyreader);
 
-    public void
+    void
     Add_Inverted_Doc(DocWriter *self, Inverter *inverter, int32_t doc_id);
 
     public void

--- a/core/Lucy/Index/HighlightReader.cfh
+++ b/core/Lucy/Index/HighlightReader.cfh
@@ -52,7 +52,7 @@ class Lucy::Index::PolyHighlightReader nickname PolyHLReader
     public incremented DocVector*
     Fetch_Doc_Vec(PolyHighlightReader *self, int32_t doc_id);
 
-    public void
+    void
     Close(PolyHighlightReader *self);
 
     public void
@@ -86,7 +86,7 @@ class Lucy::Index::DefaultHighlightReader nickname DefHLReader
     Read_Record(DefaultHighlightReader *self, int32_t doc_id,
                 ByteBuf *buffer);
 
-    public void
+    void
     Close(DefaultHighlightReader *self);
 
     public void

--- a/core/Lucy/Index/HighlightWriter.cfh
+++ b/core/Lucy/Index/HighlightWriter.cfh
@@ -38,7 +38,7 @@ class Lucy::Index::HighlightWriter nickname HLWriter
     incremented Blob*
     TV_Buf(HighlightWriter *self, Inversion *inversion);
 
-    public void
+    void
     Add_Inverted_Doc(HighlightWriter *self, Inverter *inverter, int32_t doc_id);
 
     public void

--- a/core/Lucy/Index/IndexManager.cfh
+++ b/core/Lucy/Index/IndexManager.cfh
@@ -105,45 +105,45 @@ public class Lucy::Index::IndexManager nickname IxManager
     /** Create the Lock which grants permission to delete obsolete snapshot
      * files or any file listed within an existing snapshot file.
      */
-    public incremented Lock*
+    incremented Lock*
     Make_Deletion_Lock(IndexManager *self);
 
-    public incremented Lock*
+    incremented Lock*
     Make_Merge_Lock(IndexManager *self);
 
     /** Write supplied data to "merge.json".  Throw an exception if the write
      * fails.
      */
-    public void
+    void
     Write_Merge_Data(IndexManager *self, int64_t cutoff);
 
     /** Look for the "merge.json" file dropped by BackgroundMerger.  If it's
      * not there, return NULL.  If it's there but can't be decoded, return an
      * empty Hash.  If successfully decoded, return contents.
      */
-    public incremented Hash*
+    incremented Hash*
     Read_Merge_Data(IndexManager *self);
 
-    public bool
+    bool
     Remove_Merge_Data(IndexManager *self);
 
     /** Create a shared lock on a snapshot file, which serves as a proxy for
      * all the files it lists and indicates that they must not be deleted.
      */
-    public incremented Lock*
+    incremented Lock*
     Make_Snapshot_Read_Lock(IndexManager *self, String *filename);
 
     /** Return the highest number for a segment directory which contains a
      * segmeta file in the snapshot.
      */
-    public int64_t
+    int64_t
     Highest_Seg_Num(IndexManager *self, Snapshot *snapshot);
 
     /** Return the name of a new snapshot file, which shall contain a base-36
      * "generation" embedded inside it greater than the generation of any
      * snapshot file currently in the index folder.
      */
-    public incremented String*
+    incremented String*
     Make_Snapshot_Filename(IndexManager *self);
 
     /** Setter for write lock timeout.  Default: 1000 milliseconds.
@@ -168,42 +168,42 @@ public class Lucy::Index::IndexManager nickname IxManager
 
     /** Setter for merge lock timeout.  Default: 0 milliseconds (no retries).
      */
-    public void
+    void
     Set_Merge_Lock_Timeout(IndexManager *self, uint32_t timeout);
 
     /** Getter for merge lock timeout.
      */
-    public uint32_t
+    uint32_t
     Get_Merge_Lock_Timeout(IndexManager *self);
 
     /** Setter for merge lock retry interval.  Default: 1000 milliseconds.
      */
-    public void
+    void
     Set_Merge_Lock_Interval(IndexManager *self, uint32_t timeout);
 
     /** Getter for merge lock retry interval.
      */
-    public uint32_t
+    uint32_t
     Get_Merge_Lock_Interval(IndexManager *self);
 
     /** Setter for deletion lock timeout.  Default: 1000 milliseconds.
      */
-    public void
+    void
     Set_Deletion_Lock_Timeout(IndexManager *self, uint32_t timeout);
 
     /** Getter for deletion lock timeout.
      */
-    public uint32_t
+    uint32_t
     Get_Deletion_Lock_Timeout(IndexManager *self);
 
     /** Setter for deletion lock retry interval.  Default: 100 milliseconds.
      */
-    public void
+    void
     Set_Deletion_Lock_Interval(IndexManager *self, uint32_t timeout);
 
     /** Getter for deletion lock retry interval.
      */
-    public uint32_t
+    uint32_t
     Get_Deletion_Lock_Interval(IndexManager *self);
 }
 

--- a/core/Lucy/Index/IndexReader.cfh
+++ b/core/Lucy/Index/IndexReader.cfh
@@ -113,7 +113,7 @@ public class Lucy::Index::IndexReader nickname IxReader
     public nullable DataReader*
     Fetch(IndexReader *self, String *api);
 
-    public void
+    void
     Close(IndexReader *self);
 
     Hash*

--- a/core/Lucy/Index/Indexer.cfh
+++ b/core/Lucy/Index/Indexer.cfh
@@ -165,7 +165,7 @@ public class Lucy::Index::Indexer inherits Clownfish::Obj {
 
     /** Accessor for seg_writer member var.
      */
-    public SegWriter*
+    SegWriter*
     Get_Seg_Writer(Indexer *self);
 
     Doc*

--- a/core/Lucy/Index/Lexicon.cfh
+++ b/core/Lucy/Index/Lexicon.cfh
@@ -64,7 +64,7 @@ public class Lucy::Index::Lexicon nickname Lex inherits Clownfish::Obj {
     /** Return the number of documents that the current term appears in at
      * least once.  Deleted documents may be included in the count.
      */
-    public abstract int32_t
+    abstract int32_t
     Doc_Freq(Lexicon *self);
 
     /** Return the current term, or [](cfish:@null) if the iterator is not in a
@@ -73,7 +73,7 @@ public class Lucy::Index::Lexicon nickname Lex inherits Clownfish::Obj {
     public abstract nullable Obj*
     Get_Term(Lexicon *self);
 
-    public String*
+    String*
     Get_Field(Lexicon *self);
 }
 

--- a/core/Lucy/Index/LexiconReader.cfh
+++ b/core/Lucy/Index/LexiconReader.cfh
@@ -77,7 +77,7 @@ class Lucy::Index::PolyLexiconReader nickname PolyLexReader
     public uint32_t
     Doc_Freq(PolyLexiconReader *self, String *field, Obj *term);
 
-    public void
+    void
     Close(PolyLexiconReader *self);
 
     public void
@@ -110,7 +110,7 @@ class Lucy::Index::DefaultLexiconReader nickname DefLexReader
     Fetch_Term_Info(DefaultLexiconReader *self, String *field,
                     Obj *term);
 
-    public void
+    void
     Close(DefaultLexiconReader *self);
 
     public void

--- a/core/Lucy/Index/PolyReader.cfh
+++ b/core/Lucy/Index/PolyReader.cfh
@@ -82,7 +82,7 @@ public class Lucy::Index::PolyReader inherits Lucy::Index::IndexReader {
     Vector*
     Get_Seg_Readers(PolyReader *self);
 
-    public void
+    void
     Close(PolyReader *self);
 
     public void

--- a/core/Lucy/Index/PostingListReader.cfh
+++ b/core/Lucy/Index/PostingListReader.cfh
@@ -71,7 +71,7 @@ class Lucy::Index::DefaultPostingListReader nickname DefPListReader
     LexiconReader*
     Get_Lex_Reader(DefaultPostingListReader *self);
 
-    public void
+    void
     Close(DefaultPostingListReader *self);
 
     public void

--- a/core/Lucy/Index/PostingListWriter.cfh
+++ b/core/Lucy/Index/PostingListWriter.cfh
@@ -47,7 +47,7 @@ class Lucy::Index::PostingListWriter nickname PListWriter
     inert void
     set_default_mem_thresh(size_t mem_thresh);
 
-    public void
+    void
     Add_Inverted_Doc(PostingListWriter *self, Inverter *inverter,
                      int32_t doc_id);
 

--- a/core/Lucy/Index/RawLexicon.cfh
+++ b/core/Lucy/Index/RawLexicon.cfh
@@ -45,7 +45,7 @@ class Lucy::Index::RawLexicon nickname RawLex
     public nullable Obj*
     Get_Term(RawLexicon *self);
 
-    public int32_t
+    int32_t
     Doc_Freq(RawLexicon *self);
 }
 

--- a/core/Lucy/Index/SegLexicon.cfh
+++ b/core/Lucy/Index/SegLexicon.cfh
@@ -68,7 +68,7 @@ class Lucy::Index::SegLexicon nickname SegLex
     public nullable Obj*
     Get_Term(SegLexicon *self);
 
-    public int32_t
+    int32_t
     Doc_Freq(SegLexicon *self);
 
     public bool

--- a/core/Lucy/Index/SegReader.cfh
+++ b/core/Lucy/Index/SegReader.cfh
@@ -62,7 +62,7 @@ public class Lucy::Index::SegReader inherits Lucy::Index::IndexReader {
      * interface implemented by `component`.
      * @param component A DataReader.
      */
-    public void
+    void
     Register(SegReader *self, String *api,
              decremented DataReader *component);
 

--- a/core/Lucy/Index/SegWriter.cfh
+++ b/core/Lucy/Index/SegWriter.cfh
@@ -28,7 +28,7 @@ parcel Lucy;
  * The sub-components of a SegWriter are determined by
  * [](cfish:Architecture).  DataWriter components
  * which are added to the stack of writers via [](cfish:.Add_Writer) have
- * [](cfish:.Add_Inverted_Doc) invoked for each document supplied to SegWriter's
+ * Add_Inverted_Doc() invoked for each document supplied to SegWriter's
  * [](cfish:.Add_Doc).
  */
 public class Lucy::Index::SegWriter inherits Lucy::Index::DataWriter {
@@ -89,7 +89,7 @@ public class Lucy::Index::SegWriter inherits Lucy::Index::DataWriter {
     Prep_Seg_Dir(SegWriter *self);
 
     /** Add a document to the segment.  Inverts `doc`, increments
-     * the Segment's internal document id, then calls [](cfish:.Add_Inverted_Doc),
+     * the Segment's internal document id, then calls Add_Inverted_Doc(),
      * feeding all sub-writers.
      */
     public void
@@ -103,7 +103,7 @@ public class Lucy::Index::SegWriter inherits Lucy::Index::DataWriter {
     DeletionsWriter*
     Get_Del_Writer(SegWriter *self);
 
-    public void
+    void
     Add_Inverted_Doc(SegWriter *self, Inverter *inverter, int32_t doc_id);
 
     public void

--- a/core/Lucy/Index/Segment.cfh
+++ b/core/Lucy/Index/Segment.cfh
@@ -136,7 +136,7 @@ public class Lucy::Index::Segment nickname Seg inherits Clownfish::Obj {
 
     /** Write the segdata file.
      */
-    public void
+    void
     Write_File(Segment *self, Folder *folder);
 
     /** Read the segmeta file for this segment.
@@ -144,7 +144,7 @@ public class Lucy::Index::Segment nickname Seg inherits Clownfish::Obj {
      * @return true if the file is read and decoded successfully, false
      * otherwise.
      */
-    public bool
+    bool
     Read_File(Segment *self, Folder *folder);
 
     /** Compare by segment number.

--- a/core/Lucy/Index/Similarity.cfh
+++ b/core/Lucy/Index/Similarity.cfh
@@ -47,7 +47,7 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
 
     /** Factory method for creating a Posting.
      */
-    public incremented Posting*
+    incremented Posting*
     Make_Posting(Similarity *self);
 
     /** Factory method for creating a PostingWriter.
@@ -63,7 +63,7 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
      * freqs, since the more times a doc matches, the more relevant it is
      * likely to be.
      */
-    public float
+    float
     TF(Similarity *self, float freq);
 
     /** Calculate the Inverse Document Frequecy for a term in a given
@@ -72,12 +72,12 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
      * @param doc_freq The number of documents that the term appears in.
      * @param total_docs The number of documents in the collection.
      */
-    public float
+    float
     IDF(Similarity *self, int64_t doc_freq, int64_t total_docs);
 
     /** Calculate a score factor based on the number of terms which match.
      */
-    public float
+    float
     Coord(Similarity *self, uint32_t overlap, uint32_t max_overlap);
 
     /** Dampen the scores of long documents.
@@ -101,7 +101,7 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
 
     /** Normalize a Query's weight so that it is comparable to other Queries.
      */
-    public float
+    float
     Query_Norm(Similarity *self, float sum_of_squared_weights);
 
     /** encode_norm and decode_norm encode and decode between 32-bit IEEE
@@ -123,10 +123,10 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
     public void
     Destroy(Similarity *self);
 
-    public incremented Obj*
+    incremented Obj*
     Dump(Similarity *self);
 
-    public incremented Similarity*
+    incremented Similarity*
     Load(Similarity *self, Obj *dump);
 
     public bool

--- a/core/Lucy/Index/Similarity.cfh
+++ b/core/Lucy/Index/Similarity.cfh
@@ -132,10 +132,10 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
     public bool
     Equals(Similarity *self, Obj *other);
 
-    public void
+    void
     Serialize(Similarity *self, OutStream *outstream);
 
-    public incremented Similarity*
+    incremented Similarity*
     Deserialize(decremented Similarity *self, InStream *instream);
 }
 

--- a/core/Lucy/Index/SortReader.cfh
+++ b/core/Lucy/Index/SortReader.cfh
@@ -57,7 +57,7 @@ class Lucy::Index::DefaultSortReader nickname DefSortReader
     nullable SortCache*
     Fetch_Sort_Cache(DefaultSortReader *self, String *field);
 
-    public void
+    void
     Close(DefaultSortReader *self);
 
     public void

--- a/core/Lucy/Index/SortWriter.cfh
+++ b/core/Lucy/Index/SortWriter.cfh
@@ -53,7 +53,7 @@ class Lucy::Index::SortWriter inherits Lucy::Index::DataWriter {
     inert void
     set_default_mem_thresh(size_t mem_thresh);
 
-    public void
+    void
     Add_Inverted_Doc(SortWriter *self, Inverter *inverter, int32_t doc_id);
 
     public void

--- a/core/Lucy/Index/TermVector.cfh
+++ b/core/Lucy/Index/TermVector.cfh
@@ -49,7 +49,10 @@ class Lucy::Index::TermVector nickname TV
     I32Array*
     Get_End_Offsets(TermVector *self);
 
-    public incremented TermVector*
+    void
+    Serialize(TermVector *self, OutStream *outstream);
+
+    incremented TermVector*
     Deserialize(decremented TermVector *self, InStream *instream);
 
     public bool
@@ -57,9 +60,6 @@ class Lucy::Index::TermVector nickname TV
 
     public void
     Destroy(TermVector *self);
-
-    public void
-    Serialize(TermVector *self, OutStream *outstream);
 }
 
 

--- a/core/Lucy/Object/BitVector.cfh
+++ b/core/Lucy/Object/BitVector.cfh
@@ -94,7 +94,7 @@ public class Lucy::Object::BitVector nickname BitVec
      *
      * @param other Another BitVector.
      */
-    public void
+    void
     Mimic(BitVector *self, Obj *other);
 
     /** Modify the BitVector so that only bits which remain set are those

--- a/core/Lucy/Object/I32Array.cfh
+++ b/core/Lucy/Object/I32Array.cfh
@@ -16,37 +16,37 @@
 
 parcel Lucy;
 
-class Lucy::Object::I32Array nickname I32Arr inherits Clownfish::Obj {
+public class Lucy::Object::I32Array nickname I32Arr inherits Clownfish::Obj {
     int32_t  *ints;
     uint32_t  size;
 
-    inert incremented I32Array*
+    public inert incremented I32Array*
     new(int32_t *ints, uint32_t size);
 
     inert incremented I32Array*
     new_steal(int32_t *ints, uint32_t size);
 
-    inert incremented I32Array*
+    public inert incremented I32Array*
     new_blank(uint32_t size);
 
-    inert I32Array*
+    public inert I32Array*
     init(I32Array *self, int32_t *ints, uint32_t size);
 
     /** Set the value at `tick`, or throw an error if
      * `tick` is out of bounds.
      */
-    void
+    public void
     Set(I32Array *self, uint32_t tick, int32_t value);
 
     /** Return the value at `tick`, or throw an error if
      * `tick` is out of bounds.
      */
-    int32_t
+    public int32_t
     Get(I32Array *self, uint32_t tick);
 
     /** Accessor for 'size' member.
      */
-    uint32_t
+    public uint32_t
     Get_Size(I32Array *self);
 
     public void

--- a/core/Lucy/Plan/Architecture.cfh
+++ b/core/Lucy/Plan/Architecture.cfh
@@ -39,7 +39,7 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Init_Seg_Writer(Architecture *self, SegWriter *writer);
 
     /** Spawn a LexiconWriter and [](cfish:SegWriter.Register) it with the supplied SegWriter,
@@ -47,7 +47,7 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Register_Lexicon_Writer(Architecture *self, SegWriter *writer);
 
     /** Spawn a PostingListWriter and [](cfish:SegWriter.Register) it with the supplied
@@ -56,7 +56,7 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Register_Posting_List_Writer(Architecture *self, SegWriter *writer);
 
     /** Spawn a DataWriter and [](cfish:SegWriter.Register) it with the supplied SegWriter,
@@ -72,7 +72,7 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Register_Sort_Writer(Architecture *self, SegWriter *writer);
 
     /** Spawn a HighlightWriter and [](cfish:SegWriter.Register) it with the supplied SegWriter,
@@ -80,7 +80,7 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Register_Highlight_Writer(Architecture *self, SegWriter *writer);
 
     /** Spawn a DeletionsWriter and [](cfish:SegWriter.Register) it with the supplied SegWriter,
@@ -88,15 +88,15 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param writer A SegWriter.
      */
-    public void
+    void
     Register_Deletions_Writer(Architecture *self, SegWriter *writer);
 
     /** Initialize a SegReader, registering DataReaders.
      */
-    public void
+    void
     Init_Seg_Reader(Architecture *self, SegReader *reader);
 
-    /** Spawn a DocReader and [](cfish:SegReader.Register) it with the supplied SegReader.
+    /** Spawn a DocReader and register it with the supplied SegReader.
      *
      * @param reader A SegReader.
      */
@@ -107,14 +107,14 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param reader A SegReader.
      */
-    public void
+    void
     Register_Posting_List_Reader(Architecture *self, SegReader *reader);
 
     /** Spawn a SortReader and [](cfish:SegReader.Register) it with the supplied SegReader.
      *
      * @param reader A SegReader.
      */
-    public void
+    void
     Register_Sort_Reader(Architecture *self, SegReader *reader);
 
     /** Spawn a HighlightReader and [](cfish:SegReader.Register) it with the supplied
@@ -122,32 +122,32 @@ public class Lucy::Plan::Architecture nickname Arch inherits Clownfish::Obj {
      *
      * @param reader A SegReader.
      */
-    public void
+    void
     Register_Highlight_Reader(Architecture *self, SegReader *reader);
 
     /** Spawn a LexiconReader and [](cfish:SegReader.Register) it with the supplied SegReader.
      *
      * @param reader A SegReader.
      */
-    public void
+    void
     Register_Lexicon_Reader(Architecture *self, SegReader *reader);
 
     /** Spawn a DeletionsReader and [](cfish:SegReader.Register) it with the supplied SegReader.
      *
      * @param reader A SegReader.
      */
-    public void
+    void
     Register_Deletions_Reader(Architecture *self, SegReader *reader);
 
     /** Factory method for creating a new Similarity object.
      */
-    public incremented Similarity*
+    incremented Similarity*
     Make_Similarity(Architecture *self);
 
-    public int32_t
+    int32_t
     Index_Interval(Architecture *self);
 
-    public int32_t
+    int32_t
     Skip_Interval(Architecture *self);
 
     /** Returns true for any Architecture object. Subclasses should override

--- a/core/Lucy/Plan/BlobType.cfh
+++ b/core/Lucy/Plan/BlobType.cfh
@@ -48,10 +48,10 @@ public class Lucy::Plan::BlobType inherits Lucy::Plan::FieldType {
     incremented Hash*
     Dump_For_Schema(BlobType *self);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(BlobType *self);
 
-    public incremented BlobType*
+    incremented BlobType*
     Load(BlobType *self, Obj *dump);
 
     public bool

--- a/core/Lucy/Plan/FieldType.cfh
+++ b/core/Lucy/Plan/FieldType.cfh
@@ -135,7 +135,7 @@ public abstract class Lucy::Plan::FieldType nickname FType
      * @return a negative number if a is "less than" b, 0 if they are "equal",
      * and a positive number if a is "greater than" b.
      */
-    public int32_t
+    int32_t
     Compare_Values(FieldType *self, Obj *a, Obj *b);
 
     /** NULL-safe comparison wrapper which sorts NULLs towards the back.
@@ -159,10 +159,10 @@ public abstract class Lucy::Plan::FieldType nickname FType
     abstract incremented Hash*
     Dump_For_Schema(FieldType *self);
 
-    public abstract incremented Obj*
+    abstract incremented Obj*
     Dump(FieldType *self);
 
-    public abstract incremented Obj*
+    abstract incremented Obj*
     Load(FieldType *self, Obj *dump);
 
     /** Compares all common properties.

--- a/core/Lucy/Plan/FullTextType.cfh
+++ b/core/Lucy/Plan/FullTextType.cfh
@@ -70,16 +70,16 @@ public class Lucy::Plan::FullTextType inherits Lucy::Plan::TextType {
     public Analyzer*
     Get_Analyzer(FullTextType *self);
 
-    public incremented Similarity*
+    incremented Similarity*
     Make_Similarity(FullTextType *self);
 
     incremented Hash*
     Dump_For_Schema(FullTextType *self);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(FullTextType *self);
 
-    public incremented FullTextType*
+    incremented FullTextType*
     Load(FullTextType *self, Obj *dump);
 
     public bool

--- a/core/Lucy/Plan/NumericType.cfh
+++ b/core/Lucy/Plan/NumericType.cfh
@@ -39,10 +39,10 @@ class Lucy::Plan::NumericType nickname NumType inherits Lucy::Plan::FieldType {
     incremented Hash*
     Dump_For_Schema(NumericType *self);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(NumericType *self);
 
-    public incremented NumericType*
+    incremented NumericType*
     Load(NumericType *self, Obj *dump);
 }
 

--- a/core/Lucy/Plan/Schema.cfh
+++ b/core/Lucy/Plan/Schema.cfh
@@ -97,10 +97,10 @@ public class Lucy::Plan::Schema inherits Clownfish::Obj {
     public Similarity*
     Get_Similarity(Schema *self);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(Schema *self);
 
-    public incremented Schema*
+    incremented Schema*
     Load(Schema *self, Obj *dump);
 
     /** Absorb the field definitions of another Schema, verify compatibility.

--- a/core/Lucy/Plan/StringType.cfh
+++ b/core/Lucy/Plan/StringType.cfh
@@ -39,16 +39,16 @@ public class Lucy::Plan::StringType inherits Lucy::Plan::TextType {
     public inert incremented StringType*
     new();
 
-    public incremented Similarity*
+    incremented Similarity*
     Make_Similarity(StringType *self);
 
     incremented Hash*
     Dump_For_Schema(StringType *self);
 
-    public incremented Hash*
+    incremented Hash*
     Dump(StringType *self);
 
-    public incremented StringType*
+    incremented StringType*
     Load(StringType *self, Obj *dump);
 
     public bool

--- a/core/Lucy/Search/Collector.cfh
+++ b/core/Lucy/Search/Collector.cfh
@@ -24,7 +24,7 @@ parcel Lucy;
  *
  * Collectors operate on individual segments, but must operate within the
  * context of a larger collection.  Each time the collector moves to a new
- * segment, [](cfish:.Set_Reader), [](cfish:.Set_Base) and [](cfish:.Set_Matcher) will be called, and the
+ * segment, Set_Reader(), Set_Base() and Set_Matcher() will be called, and the
  * collector must take the updated information into account.
  */
 
@@ -53,24 +53,24 @@ public abstract class Lucy::Search::Collector nickname Coll
 
     /** Setter for "reader".
      */
-    public void
+    void
     Set_Reader(Collector *self, SegReader *reader);
 
     /** Set the "base" document id, an offset which must be added to the
      * `doc_id` supplied via [](cfish:.Collect) to get the doc id for the
      * larger index.
      */
-    public void
+    void
     Set_Base(Collector *self, int32_t base);
 
     /** Indicate whether the Collector will call [](cfish:Matcher.Score) on its Matcher.
      */
-    public abstract bool
+    abstract bool
     Need_Score(Collector *self);
 
     /** Setter for "matcher".
      */
-    public void
+    void
     Set_Matcher(Collector *self, Matcher *matcher);
 }
 
@@ -101,7 +101,7 @@ public class Lucy::Search::Collector::BitCollector nickname BitColl
 
     /** Returns false, since BitCollector requires only doc ids.
      */
-    public bool
+    bool
     Need_Score(BitCollector *self);
 }
 
@@ -127,16 +127,16 @@ class Lucy::Search::Collector::OffsetCollector nickname OffsetColl
     public void
     Collect(OffsetCollector *self, int32_t doc_id);
 
-    public bool
+    bool
     Need_Score(OffsetCollector *self);
 
-    public void
+    void
     Set_Reader(OffsetCollector *self, SegReader *reader);
 
-    public void
+    void
     Set_Base(OffsetCollector *self, int32_t base);
 
-    public void
+    void
     Set_Matcher(OffsetCollector *self, Matcher *matcher);
 }
 

--- a/core/Lucy/Search/Collector/SortCollector.cfh
+++ b/core/Lucy/Search/Collector/SortCollector.cfh
@@ -71,10 +71,10 @@ class Lucy::Search::Collector::SortCollector nickname SortColl
     uint32_t
     Get_Total_Hits(SortCollector *self);
 
-    public void
+    void
     Set_Reader(SortCollector *self, SegReader *reader);
 
-    public bool
+    bool
     Need_Score(SortCollector *self);
 
     public void

--- a/core/Lucy/Search/Compiler.cfh
+++ b/core/Lucy/Search/Compiler.cfh
@@ -147,7 +147,7 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
      * @param doc_vec A DocVector.
      * @param field The name of the field.
      */
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(Compiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 

--- a/core/Lucy/Search/Compiler.cfh
+++ b/core/Lucy/Search/Compiler.cfh
@@ -151,10 +151,10 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
     Highlight_Spans(Compiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 
-    public void
+    void
     Serialize(Compiler *self, OutStream *outstream);
 
-    public incremented Compiler*
+    incremented Compiler*
     Deserialize(decremented Compiler *self, InStream *instream);
 
     public bool

--- a/core/Lucy/Search/LeafQuery.cfh
+++ b/core/Lucy/Search/LeafQuery.cfh
@@ -56,10 +56,10 @@ public class Lucy::Search::LeafQuery inherits Lucy::Search::Query {
     public incremented String*
     To_String(LeafQuery *self);
 
-    public void
+    void
     Serialize(LeafQuery *self, OutStream *outstream);
 
-    public incremented LeafQuery*
+    incremented LeafQuery*
     Deserialize(decremented LeafQuery *self, InStream *instream);
 
     public incremented Obj*

--- a/core/Lucy/Search/MatchDoc.cfh
+++ b/core/Lucy/Search/MatchDoc.cfh
@@ -31,10 +31,10 @@ class Lucy::Search::MatchDoc inherits Clownfish::Obj {
     inert MatchDoc*
     init(MatchDoc *self, int32_t doc_id, float score, Vector *values = NULL);
 
-    public void
+    void
     Serialize(MatchDoc *self, OutStream *outstream);
 
-    public incremented MatchDoc*
+    incremented MatchDoc*
     Deserialize(decremented MatchDoc *self, InStream *instream);
 
     int32_t

--- a/core/Lucy/Search/NOTQuery.cfh
+++ b/core/Lucy/Search/NOTQuery.cfh
@@ -76,7 +76,7 @@ class Lucy::Search::NOTCompiler
     public float
     Sum_Of_Squared_Weights(NOTCompiler *self);
 
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(NOTCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 }

--- a/core/Lucy/Search/NoMatchQuery.cfh
+++ b/core/Lucy/Search/NoMatchQuery.cfh
@@ -47,10 +47,10 @@ public class Lucy::Search::NoMatchQuery inherits Lucy::Search::Query {
     public incremented NoMatchQuery*
     Load(NoMatchQuery *self, Obj *dump);
 
-    public void
+    void
     Serialize(NoMatchQuery *self, OutStream *outstream);
 
-    public incremented NoMatchQuery*
+    incremented NoMatchQuery*
     Deserialize(decremented NoMatchQuery *self, InStream *instream);
 
     public bool

--- a/core/Lucy/Search/PhraseQuery.cfh
+++ b/core/Lucy/Search/PhraseQuery.cfh
@@ -57,10 +57,10 @@ public class Lucy::Search::PhraseQuery inherits Lucy::Search::Query {
     public incremented String*
     To_String(PhraseQuery *self);
 
-    public void
+    void
     Serialize(PhraseQuery *self, OutStream *outstream);
 
-    public incremented PhraseQuery*
+    incremented PhraseQuery*
     Deserialize(decremented PhraseQuery *self, InStream *instream);
 
     public incremented Obj*
@@ -107,10 +107,10 @@ class Lucy::Search::PhraseCompiler
     public bool
     Equals(PhraseCompiler *self, Obj *other);
 
-    public void
+    void
     Serialize(PhraseCompiler *self, OutStream *outstream);
 
-    public incremented PhraseCompiler*
+    incremented PhraseCompiler*
     Deserialize(decremented PhraseCompiler *self, InStream *instream);
 }
 

--- a/core/Lucy/Search/PhraseQuery.cfh
+++ b/core/Lucy/Search/PhraseQuery.cfh
@@ -100,7 +100,7 @@ class Lucy::Search::PhraseCompiler
     public void
     Apply_Norm_Factor(PhraseCompiler *self, float factor);
 
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(PhraseCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 

--- a/core/Lucy/Search/PolyQuery.cfh
+++ b/core/Lucy/Search/PolyQuery.cfh
@@ -47,10 +47,10 @@ public abstract class Lucy::Search::PolyQuery inherits Lucy::Search::Query {
     Vector*
     Get_Children(PolyQuery *self);
 
-    public void
+    void
     Serialize(PolyQuery *self, OutStream *outstream);
 
-    public incremented PolyQuery*
+    incremented PolyQuery*
     Deserialize(decremented PolyQuery *self, InStream *instream);
 
     public incremented Obj*
@@ -90,10 +90,10 @@ abstract class Lucy::Search::PolyCompiler inherits Lucy::Search::Compiler {
     public void
     Destroy(PolyCompiler *self);
 
-    public void
+    void
     Serialize(PolyCompiler *self, OutStream *outstream);
 
-    public incremented PolyCompiler*
+    incremented PolyCompiler*
     Deserialize(decremented PolyCompiler *self, InStream *instream);
 }
 

--- a/core/Lucy/Search/PolyQuery.cfh
+++ b/core/Lucy/Search/PolyQuery.cfh
@@ -83,7 +83,7 @@ abstract class Lucy::Search::PolyCompiler inherits Lucy::Search::Compiler {
     public void
     Apply_Norm_Factor(PolyCompiler *self, float factor);
 
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(PolyCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 

--- a/core/Lucy/Search/Query.cfh
+++ b/core/Lucy/Search/Query.cfh
@@ -71,10 +71,10 @@ public class Lucy::Search::Query inherits Clownfish::Obj {
     public float
     Get_Boost(Query *self);
 
-    public void
+    void
     Serialize(Query *self, OutStream *outstream);
 
-    public incremented Query*
+    incremented Query*
     Deserialize(decremented Query *self, InStream *instream);
 
     public incremented Obj*

--- a/core/Lucy/Search/RangeQuery.c
+++ b/core/Lucy/Search/RangeQuery.c
@@ -212,14 +212,14 @@ RangeQuery_Load_IMP(RangeQuery *self, Obj *dump) {
     return (Obj*)loaded;
 }
 
-RangeCompiler*
+Compiler*
 RangeQuery_Make_Compiler_IMP(RangeQuery *self, Searcher *searcher,
                              float boost, bool subordinate) {
     RangeCompiler *compiler = RangeCompiler_new(self, searcher, boost);
     if (!subordinate) {
         RangeCompiler_Normalize(compiler);
     }
-    return compiler;
+    return (Compiler*)compiler;
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/RangeQuery.cfh
+++ b/core/Lucy/Search/RangeQuery.cfh
@@ -63,10 +63,10 @@ public class Lucy::Search::RangeQuery inherits Lucy::Search::Query {
     Make_Compiler(RangeQuery *self, Searcher *searcher, float boost,
                   bool subordinate = false);
 
-    public void
+    void
     Serialize(RangeQuery *self, OutStream *outstream);
 
-    public incremented RangeQuery*
+    incremented RangeQuery*
     Deserialize(decremented RangeQuery *self, InStream *instream);
 
     public incremented Obj*

--- a/core/Lucy/Search/RangeQuery.cfh
+++ b/core/Lucy/Search/RangeQuery.cfh
@@ -59,7 +59,7 @@ public class Lucy::Search::RangeQuery inherits Lucy::Search::Query {
     public incremented String*
     To_String(RangeQuery *self);
 
-    public incremented RangeCompiler*
+    public incremented Compiler*
     Make_Compiler(RangeQuery *self, Searcher *searcher, float boost,
                   bool subordinate = false);
 

--- a/core/Lucy/Search/SortRule.cfh
+++ b/core/Lucy/Search/SortRule.cfh
@@ -62,11 +62,11 @@ public class Lucy::Search::SortRule inherits Clownfish::Obj {
     public bool
     Get_Reverse(SortRule *self);
 
-    public incremented SortRule*
-    Deserialize(decremented SortRule *self, InStream *instream);
-
-    public void
+    void
     Serialize(SortRule *self, OutStream *outstream);
+
+    incremented SortRule*
+    Deserialize(decremented SortRule *self, InStream *instream);
 
     public void
     Destroy(SortRule *self);

--- a/core/Lucy/Search/SortSpec.cfh
+++ b/core/Lucy/Search/SortSpec.cfh
@@ -41,11 +41,11 @@ public class Lucy::Search::SortSpec inherits Clownfish::Obj {
     public inert SortSpec*
     init(SortSpec *self, Vector *rules);
 
-    public incremented SortSpec*
-    Deserialize(decremented SortSpec *self, InStream *instream);
-
-    public void
+    void
     Serialize(SortSpec *self, OutStream *outstream);
+
+    incremented SortSpec*
+    Deserialize(decremented SortSpec *self, InStream *instream);
 
     Vector*
     Get_Rules(SortSpec *self);

--- a/core/Lucy/Search/TermQuery.cfh
+++ b/core/Lucy/Search/TermQuery.cfh
@@ -99,7 +99,7 @@ class Lucy::Search::TermCompiler inherits Lucy::Search::Compiler {
     public void
     Apply_Norm_Factor(TermCompiler *self, float factor);
 
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(TermCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 

--- a/core/Lucy/Search/TermQuery.cfh
+++ b/core/Lucy/Search/TermQuery.cfh
@@ -55,10 +55,10 @@ public class Lucy::Search::TermQuery inherits Lucy::Search::Query {
     public incremented String*
     To_String(TermQuery *self);
 
-    public void
+    void
     Serialize(TermQuery *self, OutStream *outstream);
 
-    public incremented TermQuery*
+    incremented TermQuery*
     Deserialize(decremented TermQuery *self, InStream *instream);
 
     public incremented Obj*
@@ -106,10 +106,10 @@ class Lucy::Search::TermCompiler inherits Lucy::Search::Compiler {
     public bool
     Equals(TermCompiler *self, Obj *other);
 
-    public void
+    void
     Serialize(TermCompiler *self, OutStream *outstream);
 
-    public incremented TermCompiler*
+    incremented TermCompiler*
     Deserialize(decremented TermCompiler *self, InStream *instream);
 }
 

--- a/core/Lucy/Search/TopDocs.cfh
+++ b/core/Lucy/Search/TopDocs.cfh
@@ -52,10 +52,10 @@ class Lucy::Search::TopDocs inherits Clownfish::Obj {
     void
     Set_Total_Hits(TopDocs *self, uint32_t total_hits);
 
-    public void
+    void
     Serialize(TopDocs *self, OutStream *outstream);
 
-    public incremented TopDocs*
+    incremented TopDocs*
     Deserialize(decremented TopDocs *self, InStream *instream);
 
     public void

--- a/core/Lucy/Store/CompoundFileReader.cfh
+++ b/core/Lucy/Store/CompoundFileReader.cfh
@@ -55,7 +55,7 @@ class Lucy::Store::CompoundFileReader nickname CFReader
     void
     Set_Path(CompoundFileReader *self, String *path);
 
-    public void
+    void
     Close(CompoundFileReader *self);
 
     public void

--- a/core/Lucy/Store/FSFolder.cfh
+++ b/core/Lucy/Store/FSFolder.cfh
@@ -38,16 +38,16 @@ public class Lucy::Store::FSFolder inherits Lucy::Store::Folder {
 
     /** Attempt to create the directory specified by `path`.
      */
-    public void
+    void
     Initialize(FSFolder *self);
 
     /** Verify that `path` is a directory.  TODO: check
      * permissions.
      */
-    public bool
+    bool
     Check(FSFolder *self);
 
-    public void
+    void
     Close(FSFolder *self);
 
     incremented nullable FileHandle*
@@ -72,10 +72,10 @@ public class Lucy::Store::FSFolder inherits Lucy::Store::Folder {
     bool
     Local_Delete(FSFolder *self, String *name);
 
-    public bool
+    bool
     Rename(FSFolder *self, String* from, String *to);
 
-    public bool
+    bool
     Hard_Link(FSFolder *self, String *from, String *to);
 }
 

--- a/core/Lucy/Store/Folder.cfh
+++ b/core/Lucy/Store/Folder.cfh
@@ -19,7 +19,7 @@ parcel Lucy;
 /** Abstract class representing a directory.
  *
  * A "file" within a Folder might be a real file on disk -- or it might be a
- * RAM buffer.  Similarly, [](cfish:.Delete) might delete a file from the file system, or
+ * RAM buffer.  Similarly, Delete() might delete a file from the file system, or
  * a key-value pair from a hash, or something else.
  *
  * The archetypal implementation of Folder,
@@ -39,7 +39,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
 
     /** Getter for `path` member var.
      */
-    public String*
+    String*
     Get_Path(Folder *self);
 
     /** Setter for `path` member var.
@@ -53,7 +53,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param path A relative filepath.
      * @return an OutStream.
      */
-    public incremented nullable OutStream*
+    incremented nullable OutStream*
     Open_Out(Folder *self,  String *path);
 
     /** Open an InStream, or set the global error object returned by
@@ -62,7 +62,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param path A relative filepath.
      * @return an InStream.
      */
-    public incremented nullable InStream*
+    incremented nullable InStream*
     Open_In(Folder *self, String *path);
 
     /** Open a FileHandle, or set the global error object returned by
@@ -72,7 +72,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param flags FileHandle flags.
      * @return a FileHandle.
      */
-    public incremented nullable FileHandle*
+    incremented nullable FileHandle*
     Open_FileHandle(Folder *self, String *path, uint32_t flags);
 
     /** Open a DirHandle or set the global error object returned by
@@ -82,7 +82,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * empty or NULL, returns a DirHandle for this Folder.
      * @return a DirHandle.
      */
-    public incremented nullable DirHandle*
+    incremented nullable DirHandle*
     Open_Dir(Folder *self, String *path = NULL);
 
     /** Create a subdirectory.
@@ -91,7 +91,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @return true on success, false on failure (sets the global error object
      * returned by [](cfish:cfish.Err.get_error)).
      */
-    public bool
+    bool
     MkDir(Folder *self, String *path);
 
     /** List all local entries within a directory.  Set the global error
@@ -117,7 +117,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param path A relative filepath.
      * @return true if `path` exists.
      */
-    public bool
+    bool
     Exists(Folder *self, String *path);
 
     /** Indicate whether a directory exists at `path`.
@@ -133,7 +133,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param path A relative filepath.
      * @return true if the deletion was successful.
      */
-    public bool
+    bool
     Delete(Folder *self, String *path);
 
     /** Delete recursively, starting at `path`
@@ -142,7 +142,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @return true if the whole tree is deleted successfully, false if any
      * part remains.
      */
-    public bool
+    bool
     Delete_Tree(Folder *self, String *path);
 
     /** Rename a file or directory, or set the global error object returned by
@@ -153,7 +153,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param to The filepath after renaming.
      * @return true on success, false on failure.
      */
-    public abstract bool
+    abstract bool
     Rename(Folder *self, String *from, String *to);
 
     /** Create a hard link at path `to` pointing at the existing
@@ -162,7 +162,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      *
      * @return true on success, false on failure.
      */
-    public abstract bool
+    abstract bool
     Hard_Link(Folder *self, String *from, String *to);
 
     /** Read a file and return its contents.
@@ -170,7 +170,7 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
      * @param path A relative filepath.
      * @param return the file's contents.
      */
-    public incremented Blob*
+    incremented Blob*
     Slurp_File(Folder *self, String *path);
 
     /** Collapse the contents of the directory into a compound file.
@@ -202,19 +202,19 @@ public abstract class Lucy::Store::Folder inherits Clownfish::Obj {
     /** Perform implementation-specific initialization.  For example: FSFolder
      * creates its own directory.
      */
-    public abstract void
+    abstract void
     Initialize(Folder *self);
 
     /** Verify that operations may be performed on this Folder.
      *
      * @return true on success.
      */
-    public abstract bool
+    abstract bool
     Check(Folder *self);
 
     /** Close the folder and release implementation-specific resources.
      */
-    public abstract void
+    abstract void
     Close(Folder *self);
 
     /** Open a FileHandle for a local file, or set the global error object

--- a/core/Lucy/Store/RAMFolder.cfh
+++ b/core/Lucy/Store/RAMFolder.cfh
@@ -33,13 +33,13 @@ public class Lucy::Store::RAMFolder inherits Lucy::Store::Folder {
     public inert RAMFolder*
     init(RAMFolder *self, String *path = NULL);
 
-    public void
+    void
     Initialize(RAMFolder *self);
 
-    public bool
+    bool
     Check(RAMFolder *self);
 
-    public void
+    void
     Close(RAMFolder *self);
 
     incremented nullable FileHandle*
@@ -63,10 +63,10 @@ public class Lucy::Store::RAMFolder inherits Lucy::Store::Folder {
     bool
     Local_Delete(RAMFolder *self, String *name);
 
-    public bool
+    bool
     Rename(RAMFolder *self, String* from, String *to);
 
-    public bool
+    bool
     Hard_Link(RAMFolder *self, String *from, String *to);
 }
 

--- a/core/Lucy/Test/Plan/TestArchitecture.cfh
+++ b/core/Lucy/Test/Plan/TestArchitecture.cfh
@@ -29,10 +29,10 @@ class Lucy::Test::Plan::TestArchitecture nickname TestArch
     inert TestArchitecture*
     init(TestArchitecture *self);
 
-    public int32_t
+    int32_t
     Index_Interval(TestArchitecture *self);
 
-    public int32_t
+    int32_t
     Skip_Interval(TestArchitecture *self);
 }
 

--- a/core/Lucy/Test/Search/TestSortSpec.cfh
+++ b/core/Lucy/Test/Search/TestSortSpec.cfh
@@ -37,7 +37,7 @@ class Lucy::Test::Search::TestReverseType inherits Lucy::Plan::Int32Type {
     init2(TestReverseType *self, float boost = 1.0, bool indexed = true,
           bool stored = true, bool sortable = false);
 
-    public int32_t
+    int32_t
     Compare_Values(TestReverseType *self, Obj *a, Obj *b);
 }
 

--- a/core/LucyX/Search/ProximityQuery.cfh
+++ b/core/LucyX/Search/ProximityQuery.cfh
@@ -107,7 +107,7 @@ class LucyX::Search::ProximityCompiler
     public void
     Apply_Norm_Factor(ProximityCompiler *self, float factor);
 
-    public incremented Vector*
+    incremented Vector*
     Highlight_Spans(ProximityCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 

--- a/core/LucyX/Search/ProximityQuery.cfh
+++ b/core/LucyX/Search/ProximityQuery.cfh
@@ -63,10 +63,10 @@ public class LucyX::Search::ProximityQuery inherits Lucy::Search::Query {
     public incremented String*
     To_String(ProximityQuery *self);
 
-    public void
+    void
     Serialize(ProximityQuery *self, OutStream *outstream);
 
-    public incremented ProximityQuery*
+    incremented ProximityQuery*
     Deserialize(decremented ProximityQuery *self, InStream *instream);
 
     public incremented Obj*
@@ -114,10 +114,10 @@ class LucyX::Search::ProximityCompiler
     public bool
     Equals(ProximityCompiler *self, Obj *other);
 
-    public void
+    void
     Serialize(ProximityCompiler *self, OutStream *outstream);
 
-    public incremented ProximityCompiler*
+    incremented ProximityCompiler*
     Deserialize(decremented ProximityCompiler *self, InStream *instream);
 }
 

--- a/perl/buildlib/Lucy/Build/Binding/Analysis.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Analysis.pm
@@ -104,6 +104,22 @@ END_CONSTRUCTOR
 }
 
 sub bind_inversion {
+    my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
+    my $synopsis = <<'END_SYNOPSIS';
+    my $result = Lucy::Analysis::Inversion->new;
+
+    while (my $token = $inversion->next) {
+        $result->append($token);
+    }
+END_SYNOPSIS
+    my $constructor = <<'END_CONSTRUCTOR';
+    my $inversion = Lucy::Analysis::Inversion->new(
+        $seed,  # optional
+    );
+END_CONSTRUCTOR
+    $pod_spec->set_synopsis($synopsis);
+    $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
+
     my $xs = <<'END_XS';
 MODULE = Lucy   PACKAGE = Lucy::Analysis::Inversion
 
@@ -139,6 +155,7 @@ END_XS
         parcel     => "Lucy",
         class_name => "Lucy::Analysis::Inversion",
     );
+    $binding->set_pod_spec($pod_spec);
     $binding->append_xs($xs);
 
     Clownfish::CFC::Binding::Perl::Class->register($binding);

--- a/perl/buildlib/Lucy/Build/Binding/Analysis.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Analysis.pm
@@ -349,6 +349,68 @@ sub bind_token {
         Get_Text
     ); 
 
+    my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
+    my $synopsis = <<'END_SYNOPSIS';
+        my $token = Lucy::Analysis::Token->new(
+            text         => 'blind',
+            start_offset => 8,
+            end_offset   => 13,
+        );
+
+        $token->set_text('mice');
+END_SYNOPSIS
+    my $constructor_pod = <<'END_CONSTRUCTOR_POD';
+=head2 new( I<[labeled params]> )
+
+    my $token = Lucy::Analysis::Token->new(
+        text         => $text,          # required
+        start_offset => $start_offset,  # required
+        end_offset   => $end_offset,    # required
+        boost        => 1.0,            # optional
+        pos_inc      => 1,              # optional
+    );
+
+=over
+
+=item *
+
+B<text> - A string.
+
+=item *
+
+B<start_offset> - Start offset into the original document in Unicode
+code points.
+
+=item *
+
+B<start_offset> - End offset into the original document in Unicode
+code points.
+
+=item *
+
+B<boost> - Per-token weight.
+
+=item *
+
+B<pos_inc> - Position increment for phrase matching.
+
+=back
+END_CONSTRUCTOR_POD
+    my $get_text_pod = <<'END_GET_TEXT_POD';
+=head2 get_text()
+
+Get the token's text.
+END_GET_TEXT_POD
+    my $set_text_pod = <<'END_SET_TEXT_POD';
+=head2 set_text(text)
+
+Set the token's text.
+END_SET_TEXT_POD
+    $pod_spec->set_synopsis($synopsis);
+    $pod_spec->add_constructor( alias => 'new', pod => $constructor_pod );
+    $pod_spec->add_method( alias => 'Get_Text', pod => $get_text_pod);
+    $pod_spec->add_method( alias => 'Set_Text', pod => $set_text_pod);
+
     my $xs = <<'END_XS';
 MODULE = Lucy    PACKAGE = Lucy::Analysis::Token
 
@@ -411,6 +473,7 @@ END_XS
         parcel     => "Lucy",
         class_name => "Lucy::Analysis::Token",
     );
+    $binding->set_pod_spec($pod_spec);
     $binding->append_xs($xs);
     $binding->exclude_method($_) for @hand_rolled;
     $binding->exclude_constructor;

--- a/perl/buildlib/Lucy/Build/Binding/Analysis.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Analysis.pm
@@ -35,13 +35,8 @@ sub bind_all {
 }
 
 sub bind_analyzer {
-    my @exposed = qw(
-        Split
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     $pod_spec->set_synopsis("    # Abstract base class.\n");
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -178,8 +173,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_polyanalyzer {
-    my @exposed = qw( Get_Analyzers );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $schema = Lucy::Plan::Schema->new;
@@ -201,7 +194,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Highlight.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Highlight.pm
@@ -45,21 +45,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_highlighter {
-    my @exposed = qw(
-        Create_Excerpt
-        Highlight
-        Encode
-        Set_Pre_Tag
-        Get_Pre_Tag
-        Set_Post_Tag
-        Get_Post_Tag
-        Get_Searcher
-        Get_Query
-        Get_Compiler
-        Get_Excerpt_Length
-        Get_Field
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $highlighter = Lucy::Highlight::Highlighter->new(
@@ -83,7 +68,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Index.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Index.pm
@@ -46,8 +46,6 @@ sub bind_all {
 }
 
 sub bind_backgroundmerger {
-    my @exposed = qw( Commit Prepare_Commit Optimize );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $bg_merger = Lucy::Index::BackgroundMerger->new(
@@ -63,7 +61,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -75,16 +72,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_datareader {
-    my @exposed = qw(
-        Get_Schema
-        Get_Folder
-        Get_Snapshot
-        Get_Segments
-        Get_Segment
-        Get_Seg_Tick
-        Aggregator
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     # Abstract base class.
@@ -100,7 +87,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -112,21 +98,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_datawriter {
-    my @exposed = qw(
-        Add_Inverted_Doc
-        Add_Segment
-        Delete_Segment
-        Merge_Segment
-        Finish
-        Format
-        Metadata
-        Get_Snapshot
-        Get_Segment
-        Get_PolyReader
-        Get_Schema
-        Get_Folder
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<END_SYNOPSIS;
     # Abstract base class.
@@ -140,7 +111,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -152,13 +122,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_deletionswriter {
-    my @exposed = qw(
-        Delete_By_Term
-        Delete_By_Query
-        Updated
-        Seg_Del_Count
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $polyreader  = $del_writer->get_polyreader;
@@ -169,7 +132,6 @@ sub bind_deletionswriter {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -181,15 +143,12 @@ END_SYNOPSIS
 }
 
 sub bind_docreader {
-    my @exposed = qw( Fetch_Doc Aggregator );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $doc_reader = $seg_reader->obtain("Lucy::Index::DocReader");
     my $doc        = $doc_reader->fetch_doc($doc_id);
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -201,18 +160,6 @@ END_SYNOPSIS
 }
 
 sub bind_indexmanager {
-    my @exposed = qw(
-        Make_Write_Lock
-        Recycle
-        Set_Folder
-        Get_Folder
-        Get_Host
-        Set_Write_Lock_Timeout
-        Get_Write_Lock_Timeout
-        Set_Write_Lock_Interval
-        Get_Write_Lock_Interval
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     use Sys::Hostname qw( hostname );
@@ -241,7 +188,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -253,16 +199,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_indexreader {
-    my @exposed = qw(
-        Doc_Max
-        Doc_Count
-        Del_Count
-        Seg_Readers
-        Offsets
-        Fetch
-        Obtain
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $reader = Lucy::Index::IndexReader->open(
@@ -293,7 +229,6 @@ END_CONSTRUCTOR
         initializer => 'do_open',
         sample      => $constructor,
     );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $xs_code = <<'END_XS_CODE';
 MODULE = Lucy    PACKAGE = Lucy::Index::IndexReader
@@ -330,16 +265,6 @@ END_XS_CODE
 }
 
 sub bind_indexer {
-    my @exposed = qw(
-        Add_Index
-        Optimize
-        Commit
-        Prepare_Commit
-        Delete_By_Term
-        Delete_By_Query
-        Delete_By_Doc_ID
-        Get_Schema
-    );
     my @hand_rolled = qw( Add_Doc );
 
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
@@ -435,7 +360,6 @@ END_ADD_DOC_POD
         alias  => 'add_doc',
         pod    => $add_doc_pod,
     );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $xs_code = <<'END_XS_CODE';
 MODULE = Lucy  PACKAGE = Lucy::Index::Indexer
@@ -516,13 +440,6 @@ END_XS_CODE
 }
 
 sub bind_lexicon {
-    my @exposed = qw(
-        Seek
-        Next
-        Get_Term
-        Reset
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $lex_reader = $seg_reader->obtain('Lucy::Index::LexiconReader');
@@ -532,7 +449,6 @@ sub bind_lexicon {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -544,15 +460,12 @@ END_SYNOPSIS
 }
 
 sub bind_lexiconreader {
-    my @exposed = qw( Lexicon Doc_Freq );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $lex_reader = $seg_reader->obtain("Lucy::Index::LexiconReader");
     my $lexicon    = $lex_reader->lexicon( field => 'title' );
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -637,14 +550,6 @@ END_XS_CODE
 }
 
 sub bind_postinglist {
-    my @exposed = qw(
-        Next
-        Advance
-        Get_Doc_ID
-        Get_Doc_Freq
-        Seek
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $posting_list_reader 
@@ -658,7 +563,6 @@ sub bind_postinglist {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -670,8 +574,6 @@ END_SYNOPSIS
 }
 
 sub bind_postinglistreader {
-    my @exposed = qw( Posting_List );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $posting_list_reader 
@@ -682,7 +584,6 @@ sub bind_postinglistreader {
     );
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -714,11 +615,6 @@ END_XS
 }
 
 sub bind_segreader {
-    my @exposed = qw(
-        Get_Seg_Name
-        Get_Seg_Num
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $polyreader = Lucy::Index::IndexReader->open(
@@ -737,7 +633,6 @@ sub bind_segreader {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -749,15 +644,7 @@ END_SYNOPSIS
 }
 
 sub bind_segwriter {
-    my @exposed = qw(
-        Add_Doc
-        Add_Writer
-        Register
-        Fetch
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -769,18 +656,6 @@ sub bind_segwriter {
 }
 
 sub bind_segment {
-    my @exposed = qw(
-        Add_Field
-        Store_Metadata
-        Fetch_Metadata
-        Field_Num
-        Field_Name
-        Get_Name
-        Get_Number
-        Set_Count
-        Get_Count
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     # Index-time.
@@ -814,7 +689,6 @@ sub bind_segment {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -826,9 +700,6 @@ END_SYNOPSIS
 }
 
 sub bind_similarity {
-    my @exposed = qw(
-        Length_Norm
-    );
     my @hand_rolled = qw( Get_Norm_Decoder );
 
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
@@ -845,7 +716,6 @@ END_SYNOPSIS
     my $constructor = qq|    my \$sim = Lucy::Index::Similarity->new;\n|;
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $xs_code = <<'END_XS_CODE';
 MODULE = Lucy    PACKAGE = Lucy::Index::Similarity
@@ -871,17 +741,6 @@ END_XS_CODE
 }
 
 sub bind_snapshot {
-    my @exposed = qw(
-        List
-        Num_Entries
-        Add_Entry
-        Delete_Entry
-        Read_File
-        Write_File
-        Set_Path
-        Get_Path
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $snapshot = Lucy::Index::Snapshot->new;
@@ -894,7 +753,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Misc.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Misc.pm
@@ -124,10 +124,6 @@ END_XS_CODE
 }
 
 sub bind_simple {
-    my @exposed = qw(
-        Search
-        Next
-    );
     my @hand_rolled = qw( Add_Doc );
 
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
@@ -181,7 +177,6 @@ END_ADD_DOC_POD
         alias  => 'add_doc',
         pod    => $add_doc_pod,
     );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $xs_code = <<'END_XS_CODE';
 MODULE = Lucy  PACKAGE = Lucy::Simple

--- a/perl/buildlib/Lucy/Build/Binding/Object.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Object.pm
@@ -26,23 +26,6 @@ sub bind_all {
 }
 
 sub bind_bitvector {
-    my @exposed = qw(
-        Get
-        Set
-        Clear
-        Clear_All
-        And
-        Or
-        And_Not
-        Xor
-        Flip
-        Flip_Block
-        Next_Hit
-        To_Array
-        Grow
-        Count
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $bit_vec = Lucy::Object::BitVector->new( capacity => 8 );
@@ -59,7 +42,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Plan.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Plan.pm
@@ -34,8 +34,6 @@ sub bind_all {
 }
 
 sub bind_architecture {
-    my @exposed = qw( Register_Doc_Writer Register_Doc_Reader );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     package MyArchitecture;
@@ -86,7 +84,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -126,14 +123,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_fieldtype {
-    my @exposed = qw(
-        Get_Boost
-        Indexed
-        Stored
-        Sortable
-        Binary
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my @sortable;
@@ -144,7 +133,6 @@ sub bind_fieldtype {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -177,12 +165,6 @@ sub bind_float64type {
 }
 
 sub bind_fulltexttype {
-    my @exposed = qw(
-        Set_Highlightable
-        Highlightable
-        Get_Analyzer
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $easyanalyzer = Lucy::Analysis::EasyAnalyzer->new(
@@ -207,7 +189,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -240,17 +221,6 @@ sub bind_int64type {
 }
 
 sub bind_schema {
-    my @exposed = qw(
-        Spec_Field
-        Num_Fields
-        All_Fields
-        Fetch_Type
-        Fetch_Sim
-        Architecture
-        Get_Architecture
-        Get_Similarity
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     use Lucy::Plan::Schema;
@@ -272,7 +242,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Search.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Search.pm
@@ -51,8 +51,6 @@ sub bind_all {
 }
 
 sub bind_andquery {
-    my @exposed = qw( Add_Child );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $foo_and_bar_query = Lucy::Search::ANDQuery->new(
@@ -68,7 +66,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -80,8 +77,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_collector {
-    my @exposed = qw( Collect );
-
     my $pod_spec    = Clownfish::CFC::Binding::Perl::Pod->new;
     my $constructor = <<'END_CONSTRUCTOR';
     package MyCollector;
@@ -96,7 +91,6 @@ sub bind_collector {
 END_CONSTRUCTOR
     $pod_spec->set_synopsis("    # Abstract base class.\n");
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -108,8 +102,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_bitcollector {
-    my @exposed = qw( Collect );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $bit_vec = Lucy::Object::BitVector->new(
@@ -130,7 +122,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -142,17 +133,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_compiler {
-    my @exposed = qw(
-        Make_Matcher
-        Get_Weight
-        Sum_Of_Squared_Weights
-        Apply_Norm_Factor
-        Normalize
-        Get_Parent
-        Get_Similarity
-        Highlight_Spans
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     # (Compiler is an abstract base class.)
@@ -174,7 +154,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR_CODE_SAMPLE
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -187,8 +166,6 @@ END_CONSTRUCTOR_CODE_SAMPLE
 }
 
 sub bind_hits {
-    my @exposed = qw( Next Total_Hits );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $hits = $searcher->hits(
@@ -201,7 +178,6 @@ sub bind_hits {
     }
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -213,16 +189,6 @@ END_SYNOPSIS
 }
 
 sub bind_indexsearcher {
-    my @exposed = qw(
-        Hits
-        Collect
-        Doc_Max
-        Doc_Freq
-        Fetch_Doc
-        Get_Schema
-        Get_Reader
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $searcher = Lucy::Search::IndexSearcher->new( 
@@ -241,7 +207,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -253,8 +218,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_leafquery {
-    my @exposed = qw( Get_Field Get_Text );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     package MyQueryParser;
@@ -281,7 +244,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -309,13 +271,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_matcher {
-    my @exposed = qw(
-        Next
-        Advance
-        Get_Doc_ID
-        Score
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     # abstract base class
@@ -325,7 +280,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR_CODE_SAMPLE
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -337,11 +291,6 @@ END_CONSTRUCTOR_CODE_SAMPLE
 }
 
 sub bind_notquery {
-    my @exposed = qw(
-        Get_Negated_Query
-        Set_Negated_Query
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $not_bar_query = Lucy::Search::NOTQuery->new( 
@@ -360,7 +309,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -388,8 +336,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_orquery {
-    my @exposed = qw( Add_Child );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $foo_or_bar_query = Lucy::Search::ORQuery->new(
@@ -405,7 +351,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -499,8 +444,6 @@ END_XS_CODE
 }
 
 sub bind_phrasequery {
-    my @exposed = qw( Get_Field Get_Terms );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $phrase_query = Lucy::Search::PhraseQuery->new( 
@@ -511,7 +454,6 @@ sub bind_phrasequery {
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new' );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -559,14 +501,6 @@ END_SYNOPSIS
 }
 
 sub bind_polysearcher {
-    my @exposed = qw(
-        Hits
-        Doc_Max
-        Doc_Freq
-        Fetch_Doc
-        Get_Schema
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $schema = MySchema->new;
@@ -587,7 +521,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -599,8 +532,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_query {
-    my @exposed = qw( Make_Compiler Set_Boost Get_Boost );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     # Query is an abstract base class.
@@ -626,7 +557,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR_CODE_SAMPLE
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -638,21 +568,6 @@ END_CONSTRUCTOR_CODE_SAMPLE
 }
 
 sub bind_queryparser {
-    my @exposed = qw(
-        Parse
-        Tree
-        Expand
-        Expand_Leaf
-        Prune
-        Set_Heed_Colons
-        Make_Term_Query
-        Make_Phrase_Query
-        Make_AND_Query
-        Make_OR_Query
-        Make_NOT_Query
-        Make_Req_Opt_Query
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $query_parser = Lucy::Search::QueryParser->new(
@@ -672,7 +587,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -724,13 +638,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_requiredoptionalquery {
-    my @exposed = qw(
-        Get_Required_Query
-        Set_Required_Query
-        Get_Optional_Query
-        Set_Optional_Query
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $foo_and_maybe_bar = Lucy::Search::RequiredOptionalQuery->new(
@@ -748,7 +655,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -760,16 +666,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_searcher {
-    my @exposed = qw(
-        Hits
-        Collect
-        Glean_Query
-        Doc_Max
-        Doc_Freq
-        Fetch_Doc
-        Get_Schema
-    );
-
     my $pod_spec    = Clownfish::CFC::Binding::Perl::Pod->new;
     my $constructor = <<'END_CONSTRUCTOR';
     package MySearcher;
@@ -782,7 +678,6 @@ sub bind_searcher {
 END_CONSTRUCTOR
     $pod_spec->set_synopsis("    # Abstract base class.\n");
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -794,8 +689,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_sortrule {
-    my @exposed = qw( Get_Field Get_Reverse );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $sort_spec = Lucy::Search::SortSpec->new(
@@ -816,7 +709,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $xs_code = <<'END_XS_CODE';
 MODULE = Lucy   PACKAGE = Lucy::Search::SortRule
@@ -881,15 +773,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_span {
-    my @exposed = qw(
-        Set_Offset
-        Get_Offset
-        Set_Length
-        Get_Length
-        Set_Weight
-        Get_Weight
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $combined_length = $upper_span->get_length
@@ -909,7 +792,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -921,8 +803,6 @@ END_CONSTRUCTOR
 }
 
 sub bind_termquery {
-    my @exposed = qw( Get_Field Get_Term );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $term_query = Lucy::Search::TermQuery->new(
@@ -939,7 +819,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/Lucy/Build/Binding/Store.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Store.pm
@@ -214,14 +214,6 @@ END_XS_CODE
 }
 
 sub bind_lock {
-    my @exposed = qw(
-        Obtain
-        Request
-        Release
-        Is_Locked
-        Clear_Stale
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $lock = $lock_factory->make_lock(
@@ -243,7 +235,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
@@ -283,11 +274,6 @@ END_SYNOPSIS
 }
 
 sub bind_lockfactory {
-    my @exposed = qw(
-        Make_Lock
-        Make_Shared_Lock
-    );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     use Sys::Hostname qw( hostname );
@@ -313,7 +299,6 @@ END_SYNOPSIS
 END_CONSTRUCTOR
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', sample => $constructor, );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/buildlib/LucyX/Build/Binding/Search.pm
+++ b/perl/buildlib/LucyX/Build/Binding/Search.pm
@@ -46,8 +46,6 @@ sub bind_mockmatcher {
 }
 
 sub bind_proximityquery {
-    my @exposed = qw( Get_Field Get_Terms Get_Within );
-
     my $pod_spec = Clownfish::CFC::Binding::Perl::Pod->new;
     my $synopsis = <<'END_SYNOPSIS';
     my $proximity_query = LucyX::Search::ProximityQuery->new( 
@@ -59,7 +57,6 @@ sub bind_proximityquery {
 END_SYNOPSIS
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new' );
-    $pod_spec->add_method( method => $_, alias => lc($_) ) for @exposed;
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",

--- a/perl/t/200-doc.t
+++ b/perl/t/200-doc.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 11;
+use Test::More tests => 12;
 use Storable qw( nfreeze thaw );
 use Lucy::Test;
 
@@ -29,6 +29,9 @@ is_deeply( $doc->get_fields, { foo => 'oink' }, "set_fields" );
 
 $doc->{foo} = "blah";
 is_deeply( $doc->get_fields, { foo => 'blah' }, "overloading" );
+
+$doc->store(title => "A title");
+is_deeply( $doc->extract('title'), "A title", "store/extract" );
 
 my %hash = ( foo => 'foo' );
 $doc = Lucy::Document::Doc->new(


### PR DESCRIPTION
The Clownfish branch `perl_pod` adds POD for public novel methods by default, making it possible to remove the POD "whitelists".

This branch also adds Perl documentation for Analyzer, Inversion, and Token, which is needed to write custom analyzers. It also removes documentation for some methods taking private classes as parameters.