### PR TITLE
LUCY-282 Refine Go bindings pt1

### DIFF
--- a/core/Lucy/Search/ANDMatcher.cfh
+++ b/core/Lucy/Search/ANDMatcher.cfh
@@ -26,10 +26,10 @@ class Lucy::Search::ANDMatcher inherits Lucy::Search::PolyMatcher {
     bool          first_time;
 
     inert incremented ANDMatcher*
-    new(Vector *children, Similarity *sim);
+    new(Vector *children, Similarity *sim = NULL);
 
     inert ANDMatcher*
-    init(ANDMatcher *self, Vector *children, Similarity *similarity);
+    init(ANDMatcher *self, Vector *children, Similarity *similarity = NULL);
 
     public void
     Destroy(ANDMatcher *self);

--- a/core/Lucy/Search/ORMatcher.cfh
+++ b/core/Lucy/Search/ORMatcher.cfh
@@ -79,10 +79,10 @@ class Lucy::Search::ORScorer inherits Lucy::Search::ORMatcher {
     int32_t           doc_id;
 
     inert incremented ORScorer*
-    new(Vector *children, Similarity *similarity);
+    new(Vector *children, Similarity *similarity = NULL);
 
     inert ORScorer*
-    init(ORScorer *self, Vector *children, Similarity *similarity);
+    init(ORScorer *self, Vector *children, Similarity *similarity = NULL);
 
     public void
     Destroy(ORScorer *self);

--- a/core/Lucy/Search/PolyMatcher.cfh
+++ b/core/Lucy/Search/PolyMatcher.cfh
@@ -28,10 +28,10 @@ class Lucy::Search::PolyMatcher inherits Lucy::Search::Matcher {
     float        *coord_factors;
 
     inert incremented PolyMatcher*
-    new(Vector *children, Similarity *similarity);
+    new(Vector *children, Similarity *similarity = NULL);
 
     inert PolyMatcher*
-    init(PolyMatcher *self, Vector *children, Similarity *similarity);
+    init(PolyMatcher *self, Vector *children, Similarity *similarity = NULL);
 
     public void
     Destroy(PolyMatcher *self);

--- a/core/Lucy/Search/RequiredOptionalMatcher.cfh
+++ b/core/Lucy/Search/RequiredOptionalMatcher.cfh
@@ -27,11 +27,11 @@ class Lucy::Search::RequiredOptionalMatcher nickname ReqOptMatcher
     bool          opt_matcher_first_time;
 
     inert incremented RequiredOptionalMatcher*
-    new(Similarity *similarity, Matcher *required_matcher,
+    new(Similarity *similarity = NULL, Matcher *required_matcher,
         Matcher *optional_matcher = NULL);
 
     inert RequiredOptionalMatcher*
-    init(RequiredOptionalMatcher *self, Similarity *similarity,
+    init(RequiredOptionalMatcher *self, Similarity *similarity = NULL,
          Matcher *required_matcher, Matcher *optional_matcher = NULL);
 
     public void

--- a/core/LucyX/Search/MockMatcher.c
+++ b/core/LucyX/Search/MockMatcher.c
@@ -30,6 +30,12 @@ MockMatcher*
 MockMatcher_init(MockMatcher *self, I32Array *doc_ids, Blob *scores) {
     Matcher_init((Matcher*)self);
     MockMatcherIVARS *const ivars = MockMatcher_IVARS(self);
+    size_t num_doc_ids = I32Arr_Get_Size(doc_ids);
+    size_t num_scores = scores ? Blob_Get_Size(scores) / sizeof(float) : 0;
+    if (scores != NULL && num_scores != num_doc_ids) {
+        THROW(ERR, "Num doc IDs != num scores (%u64, %u64)",
+              (uint64_t)num_doc_ids, (uint64_t)num_scores);
+    }
     ivars->tick    = -1;
     ivars->size    = I32Arr_Get_Size(doc_ids);
     ivars->doc_ids = (I32Array*)INCREF(doc_ids);

--- a/go/build.go
+++ b/go/build.go
@@ -167,6 +167,10 @@ func specClasses(parcel *cfc.Parcel) {
 	orQueryBinding := cfc.NewGoClass(parcel, "Lucy::Search::ORQuery")
 	orQueryBinding.SetSuppressCtor(true)
 	orQueryBinding.Register()
+
+	bitVecBinding := cfc.NewGoClass(parcel, "Lucy::Object::BitVector")
+	bitVecBinding.SpecMethod("To_Array", "ToArray() []bool")
+	bitVecBinding.Register()
 }
 
 func build() {

--- a/go/build.go
+++ b/go/build.go
@@ -159,6 +159,14 @@ func specClasses(parcel *cfc.Parcel) {
 	hitsBinding.SpecMethod("", "Error() error")
 	hitsBinding.SetSuppressStruct(true)
 	hitsBinding.Register()
+
+	andQueryBinding := cfc.NewGoClass(parcel, "Lucy::Search::ANDQuery")
+	andQueryBinding.SetSuppressCtor(true)
+	andQueryBinding.Register()
+
+	orQueryBinding := cfc.NewGoClass(parcel, "Lucy::Search::ORQuery")
+	orQueryBinding.SetSuppressCtor(true)
+	orQueryBinding.Register()
 }
 
 func build() {

--- a/go/build.go
+++ b/go/build.go
@@ -168,6 +168,18 @@ func specClasses(parcel *cfc.Parcel) {
 	orQueryBinding.SetSuppressCtor(true)
 	orQueryBinding.Register()
 
+	andMatcherBinding := cfc.NewGoClass(parcel, "Lucy::Search::ANDMatcher")
+	andMatcherBinding.SetSuppressCtor(true)
+	andMatcherBinding.Register()
+
+	orMatcherBinding := cfc.NewGoClass(parcel, "Lucy::Search::ORMatcher")
+	orMatcherBinding.SetSuppressCtor(true)
+	orMatcherBinding.Register()
+
+	orScorerBinding := cfc.NewGoClass(parcel, "Lucy::Search::ORScorer")
+	orScorerBinding.SetSuppressCtor(true)
+	orScorerBinding.Register()
+
 	bitVecBinding := cfc.NewGoClass(parcel, "Lucy::Object::BitVector")
 	bitVecBinding.SpecMethod("To_Array", "ToArray() []bool")
 	bitVecBinding.Register()

--- a/go/build.go
+++ b/go/build.go
@@ -171,6 +171,10 @@ func specClasses(parcel *cfc.Parcel) {
 	bitVecBinding := cfc.NewGoClass(parcel, "Lucy::Object::BitVector")
 	bitVecBinding.SpecMethod("To_Array", "ToArray() []bool")
 	bitVecBinding.Register()
+
+	mockMatcherBinding := cfc.NewGoClass(parcel, "LucyX::Search::MockMatcher")
+	mockMatcherBinding.SetSuppressCtor(true)
+	mockMatcherBinding.Register()
 }
 
 func build() {

--- a/go/lucy/lucy.go
+++ b/go/lucy/lucy.go
@@ -191,6 +191,7 @@ func init() {
 	C.GOLUCY_glue_exported_symbols()
 	C.lucy_bootstrap_parcel()
 	registry = newObjRegistry(16)
+	initWRAP()
 }
 
 //export GOLUCY_RegexTokenizer_init

--- a/go/lucy/object.go
+++ b/go/lucy/object.go
@@ -18,11 +18,13 @@ package lucy
 
 /*
 #include "Lucy/Object/BitVector.h"
+#include "Lucy/Object/I32Array.h"
 */
 import "C"
 import "fmt"
+import "unsafe"
 
-import _ "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
 
 func (bv *BitVectorIMP) ToArray() []bool {
 	cap := bv.GetCapacity()
@@ -36,3 +38,14 @@ func (bv *BitVectorIMP) ToArray() []bool {
 	return bools
 }
 
+func NewI32Array(nums []int32) I32Array {
+	size := len(nums)
+	if int(C.uint32_t(size)) != size {
+		panic(clownfish.NewErr("input too large"))
+	}
+	obj := C.lucy_I32Arr_new_blank(C.uint32_t(size))
+	for i := 0; i < size; i++ {
+		C.LUCY_I32Arr_Set(obj, C.uint32_t(i), C.int32_t(nums[i]))
+	}
+	return WRAPI32Array(unsafe.Pointer(obj))
+}

--- a/go/lucy/object.go
+++ b/go/lucy/object.go
@@ -1,0 +1,38 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+/*
+#include "Lucy/Object/BitVector.h"
+*/
+import "C"
+import "fmt"
+
+import _ "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
+func (bv *BitVectorIMP) ToArray() []bool {
+	cap := bv.GetCapacity()
+	if cap != uint32(int(cap)) {
+		panic(fmt.Sprintf("Capacity of range: %d", cap))
+	}
+	bools := make([]bool, int(cap))
+	for i := uint32(0); i < cap; i++ {
+		bools[i] = bv.Get(i)
+	}
+	return bools
+}
+

--- a/go/lucy/object_test.go
+++ b/go/lucy/object_test.go
@@ -119,4 +119,13 @@ func TestBitVecBool(t *testing.T) {
 	}
 }
 
-
+func TestI32ArrBasics(t *testing.T) {
+	arr := NewI32Array([]int32{42, 43})
+	if size := arr.GetSize(); size != 2 {
+		t.Errorf("Unexpected size: %d", size)
+	}
+	arr.Set(1, 101)
+	if got := arr.Get(1); got != 101 {
+		t.Errorf("Unexpected value: %d", got)
+	}
+}

--- a/go/lucy/object_test.go
+++ b/go/lucy/object_test.go
@@ -1,0 +1,122 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "testing"
+import _ "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
+func TestBitVecSingle(t *testing.T) {
+	bitVec := NewBitVector(0)
+	if bitVec.Get(31) {
+		t.Error("Get for unset bit")
+	}
+	bitVec.Set(31)
+	if !bitVec.Get(31) {
+		t.Error("Get for true bit")
+	}
+	bitVec.Clear(31)
+	if bitVec.Get(31) {
+		t.Error("Get for cleared bit")
+	}
+	bitVec.Flip(31)
+	if !bitVec.Get(31) {
+		t.Error("Get for flipped bit")
+	}
+	if hit := bitVec.NextHit(0); hit != 31 {
+		t.Error("NextHit should find hit")
+	}
+	if hit := bitVec.NextHit(32); hit != -1 {
+		t.Error("NextHit exhausted")
+	}
+}
+
+func TestBitVecMisc(t *testing.T) {
+	bitVec := NewBitVector(0)
+	oldCap := bitVec.GetCapacity()
+	bitVec.Grow(64)
+	if newCap := bitVec.GetCapacity(); newCap <= oldCap {
+		t.Error("Grow/GetCapacity had unexpected result: %v %v", oldCap, newCap)
+	}
+	bitVec.Set(0)
+	bitVec.Set(63)
+	bools := bitVec.ToArray()
+	count := 0;
+	for _, val := range bools {
+		if val {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Error("ToArray yielded bad count: %d", count)
+	}
+}
+
+func TestBitVecBlock(t *testing.T) {
+	bitVec := NewBitVector(0)
+	bitVec.FlipBlock(10, 10)
+	if count := bitVec.Count(); count != 10 {
+		t.Error("FlipBlock")
+	}
+	bitVec.FlipBlock(15, 5)
+	if count := bitVec.Count(); count != 5 {
+		t.Error("FlipBlock mixed")
+	}
+	bitVec.ClearAll()
+	if count := bitVec.Count(); count != 0 {
+		t.Error("ClearAll")
+	}
+}
+
+func TestBitVecBool(t *testing.T) {
+	var dupe BitVector
+	seven := NewBitVector(0);
+	twelve := NewBitVector(0);
+	seven.FlipBlock(0, 3) // 0111
+	twelve.FlipBlock(2, 2) // 1100
+
+	dupe = seven.Clone().(BitVector)
+	dupe.And(twelve)
+	if count := dupe.Count(); count != 1 {
+		t.Errorf("And: %d", count)
+	}
+
+	dupe = seven.Clone().(BitVector)
+	dupe.Or(twelve)
+	if count := dupe.Count(); count != 4 {
+		t.Errorf("Or: %d", count)
+	}
+
+	dupe = seven.Clone().(BitVector)
+	dupe.Xor(twelve)
+	if count := dupe.Count(); count != 3 {
+		t.Errorf("Xor: %d", count)
+	}
+
+	dupe = seven.Clone().(BitVector)
+	dupe.AndNot(twelve)
+	if count := dupe.Count(); count != 2 {
+		t.Errorf("AndNot: %d", count)
+	}
+
+	dupe = seven.Clone().(BitVector)
+	dupe.Mimic(twelve)
+	if count := dupe.Count(); count != twelve.Count() {
+		t.Errorf("Mimic: %d", count)
+	}
+}
+
+

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -24,6 +24,8 @@ package lucy
 #include "Lucy/Search/Searcher.h"
 #include "Lucy/Search/ANDQuery.h"
 #include "Lucy/Search/ORQuery.h"
+#include "Lucy/Search/ANDMatcher.h"
+#include "Lucy/Search/ORMatcher.h"
 #include "Lucy/Document/HitDoc.h"
 #include "LucyX/Search/MockMatcher.h"
 #include "Clownfish/Blob.h"
@@ -190,6 +192,38 @@ func NewORQuery(children []Query) ORQuery {
 	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
 	cfObj := C.lucy_ORQuery_new(childrenC)
 	return WRAPORQuery(unsafe.Pointer(cfObj))
+}
+
+func NewANDMatcher(children []Matcher, sim Similarity) ANDMatcher {
+	simC := (*C.lucy_Similarity)(clownfish.UnwrapNullable(sim))
+	vec := clownfish.NewVector(len(children))
+	for _, child := range children {
+		vec.Push(child)
+	}
+	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
+	cfObj := C.lucy_ANDMatcher_new(childrenC, simC)
+	return WRAPANDMatcher(unsafe.Pointer(cfObj))
+}
+
+func NewORMatcher(children []Matcher) ORMatcher {
+	vec := clownfish.NewVector(len(children))
+	for _, child := range children {
+		vec.Push(child)
+	}
+	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
+	cfObj := C.lucy_ORMatcher_new(childrenC)
+	return WRAPORMatcher(unsafe.Pointer(cfObj))
+}
+
+func NewORScorer(children []Matcher, sim Similarity) ORScorer {
+	simC := (*C.lucy_Similarity)(clownfish.UnwrapNullable(sim))
+	vec := clownfish.NewVector(len(children))
+	for _, child := range children {
+		vec.Push(child)
+	}
+	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
+	cfObj := C.lucy_ORScorer_new(childrenC, simC)
+	return WRAPORScorer(unsafe.Pointer(cfObj))
 }
 
 func newMockMatcher(docIDs []int32, scores []float32) MockMatcher {

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -22,6 +22,8 @@ package lucy
 #include "Lucy/Search/IndexSearcher.h"
 #include "Lucy/Search/Query.h"
 #include "Lucy/Search/Searcher.h"
+#include "Lucy/Search/ANDQuery.h"
+#include "Lucy/Search/ORQuery.h"
 #include "Lucy/Document/HitDoc.h"
 #include "Clownfish/Hash.h"
 #include "Clownfish/HashIterator.h"
@@ -160,4 +162,24 @@ func (obj *HitsIMP) Next(hit interface{}) bool {
 
 func (obj *HitsIMP) Error() error {
 	return obj.err
+}
+
+func NewANDQuery(children []Query) ANDQuery {
+	vec := clownfish.NewVector(len(children))
+	for _, child := range children {
+		vec.Push(child)
+	}
+	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
+	cfObj := C.lucy_ANDQuery_new(childrenC)
+	return WRAPANDQuery(unsafe.Pointer(cfObj))
+}
+
+func NewORQuery(children []Query) ORQuery {
+	vec := clownfish.NewVector(len(children))
+	for _, child := range children {
+		vec.Push(child)
+	}
+	childrenC := (*C.cfish_Vector)(unsafe.Pointer(vec.TOPTR()))
+	cfObj := C.lucy_ORQuery_new(childrenC)
+	return WRAPORQuery(unsafe.Pointer(cfObj))
 }

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -40,14 +40,8 @@ type HitsIMP struct {
 }
 
 func OpenIndexSearcher(index interface{}) (obj IndexSearcher, err error) {
-	var indexC *C.cfish_Obj
-	switch index.(type) {
-	case string:
-		ixLoc := clownfish.NewString(index.(string))
-		indexC = (*C.cfish_Obj)(unsafe.Pointer(ixLoc.TOPTR()))
-	default:
-		panic("TODO: support Folder")
-	}
+	indexC := (*C.cfish_Obj)(clownfish.GoToClownfish(index, unsafe.Pointer(C.CFISH_OBJ), false))
+	defer C.cfish_decref(unsafe.Pointer(indexC))
 	err = clownfish.TrapErr(func() {
 		cfObj := C.lucy_IxSearcher_new(indexC)
 		obj = WRAPIndexSearcher(unsafe.Pointer(cfObj))

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -1,0 +1,251 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "testing"
+import "strings"
+import "reflect"
+import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
+func checkQuerySerialize(t *testing.T, query Query) {
+	folder := NewRAMFolder("")
+	outStream := folder.OpenOut("foo")
+	query.Serialize(outStream)
+	outStream.Close()
+	inStream := folder.OpenIn("foo")
+	dupe := clownfish.GetClass(query).MakeObj().(Query).Deserialize(inStream)
+	if !query.Equals(dupe) {
+		t.Errorf("Unsuccessful serialization round trip -- expected '%v', got '%v'",
+				 query.ToString(), dupe.ToString())
+	}
+}
+
+func checkQueryDumpLoad(t *testing.T, query Query) {
+	dupe := clownfish.GetClass(query).MakeObj().(Query)
+	dupe = dupe.Load(query.Dump()).(Query)
+	if !query.Equals(dupe) {
+		t.Errorf("Unsuccessful Dump/Load round trip -- expected '%v', got '%v'",
+				 query.ToString(), dupe.ToString())
+	}
+}
+
+func checkQueryEquals(t *testing.T, query Query) {
+	if !query.Equals(query) {
+		t.Error("Equals self")
+	}
+	if query.Equals("blah") {
+		t.Error("Equals against Go string")
+	}
+}
+
+func checkQueryMakeCompiler(t *testing.T, query Query) {
+	index := createTestIndex("foo", "bar", "baz")
+	searcher, _ := OpenIndexSearcher(index)
+	compiler := query.MakeCompiler(searcher, 1.0, false)
+	if got, ok := compiler.(Compiler); !ok {
+		t.Error("MakeCompiler failed: got '%v'", got)
+	}
+}
+
+// Test whether ToString() yields a string which contains "foo".
+func checkQueryToStringHasFoo(t *testing.T, query Query) {
+	if got := query.ToString(); !strings.Contains(got, "foo") {
+		t.Errorf("Unexpected stringification: '%v'", got)
+	}
+}
+
+func TestTermQueryMisc(t *testing.T) {
+	query := NewTermQuery("content", "foo")
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestTermQueryAccessors(t *testing.T) {
+	query := NewTermQuery("content", "foo")
+	if got := query.GetField(); got != "content" {
+		t.Errorf("Expected 'content', got '%v'", got)
+	}
+	if got := query.GetTerm().(string); got != "foo" {
+		t.Errorf("Expected 'foo', got '%v'", got)
+	}
+}
+
+func TestTermCompilerMisc(t *testing.T) {
+	folder := createTestIndex("foo", "bar", "baz")
+	searcher, _ := OpenIndexSearcher(folder)
+	query := NewTermQuery("content", "foo")
+	compiler := NewTermCompiler(query, searcher, 1.0)
+	checkQuerySerialize(t, compiler) 
+	checkQueryEquals(t, compiler)
+	checkQueryToStringHasFoo(t, compiler)
+}
+
+func TestTermCompilerWeighting(t *testing.T) {
+	index := createTestIndex("foo", "bar", "baz")
+	searcher, _ := OpenIndexSearcher(index)
+	query := NewTermQuery("content", "foo")
+	compiler := NewTermCompiler(query, searcher, 1.0)
+	_ = compiler.SumOfSquaredWeights()
+	_ = compiler.GetWeight()
+	compiler.ApplyNormFactor(10.0)
+}
+
+func TestPhraseQueryMisc(t *testing.T) {
+	terms := []interface{}{"foo", "bar"}
+	query := NewPhraseQuery("content", terms)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestPhraseQueryAccessors(t *testing.T) {
+	terms := []interface{}{"foo", "bar"}
+	query := NewPhraseQuery("content", terms)
+	if field := query.GetField(); field != "content" {
+		t.Errorf("Expected 'content', got '%v'", field)
+	}
+	if got := query.GetTerms(); !reflect.DeepEqual(terms, got) {
+		t.Errorf("Expected '%v', got '%v'", terms, got)
+	}
+}
+
+func TestPhraseCompilerMisc(t *testing.T) {
+	folder := createTestIndex("foo", "bar", "baz")
+	searcher, _ := OpenIndexSearcher(folder)
+	terms := []interface{}{"foo", "bar"}
+	query := NewPhraseQuery("content", terms)
+	compiler := NewPhraseCompiler(query, searcher, 1.0)
+	checkQuerySerialize(t, compiler) 
+	checkQueryEquals(t, compiler)
+	checkQueryToStringHasFoo(t, compiler)
+}
+
+func TestPhraseCompilerWeighting(t *testing.T) {
+	index := createTestIndex("foo", "bar", "baz")
+	searcher, _ := OpenIndexSearcher(index)
+	terms := []interface{}{"foo", "bar"}
+	query := NewPhraseQuery("content", terms)
+	compiler := NewPhraseCompiler(query, searcher, 1.0)
+	_ = compiler.SumOfSquaredWeights()
+	_ = compiler.GetWeight()
+	compiler.ApplyNormFactor(10.0)
+}
+
+func TestANDQueryBasics(t *testing.T) {
+	children := []Query{
+		NewTermQuery("content", "foo"),
+		NewTermQuery("content", "bar"),
+	}
+	query := NewANDQuery(children)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestORQueryBasics(t *testing.T) {
+	children := []Query{
+		NewTermQuery("content", "foo"),
+		NewTermQuery("content", "bar"),
+	}
+	query := NewORQuery(children)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestReqOptQueryBasics(t *testing.T) {
+	req := NewTermQuery("content", "foo")
+	opt := NewTermQuery("content", "bar")
+	query := NewRequiredOptionalQuery(req, opt)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestReqOptQueryAccessors(t *testing.T) {
+	req := NewTermQuery("content", "foo")
+	opt := NewTermQuery("content", "bar")
+	query := NewRequiredOptionalQuery(req, opt)
+	if query.GetRequiredQuery().TOPTR() != req.TOPTR() {
+		t.Errorf("GetRequiredQuery")
+	}
+	if query.GetOptionalQuery().TOPTR() != opt.TOPTR() {
+		t.Errorf("GetOptionalQuery")
+	}
+}
+
+func TestNOTQueryBasics(t *testing.T) {
+	negated := NewTermQuery("content", "foo")
+	query := NewNOTQuery(negated)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestNOTQueryAccessors(t *testing.T) {
+	negated := NewTermQuery("content", "foo")
+	query := NewNOTQuery(negated)
+	if query.GetNegatedQuery().TOPTR() != negated.TOPTR() {
+		t.Errorf("GetNegatedQuery")
+	}
+}
+
+func TestMatchAllQueryBasics(t *testing.T) {
+	query := NewMatchAllQuery()
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+}
+
+func TestNOMatchQueryBasics(t *testing.T) {
+	query := NewNoMatchQuery()
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+}
+
+func TestRangeQueryBasics(t *testing.T) {
+	query := NewRangeQuery("content", "fab", "foo", true, true)
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryMakeCompiler(t, query)
+	checkQueryToStringHasFoo(t, query)
+}
+
+func TestLeafQueryBasics(t *testing.T) {
+	query := NewLeafQuery("content", "foo")
+	checkQuerySerialize(t, query)
+	checkQueryDumpLoad(t, query)
+	checkQueryEquals(t, query)
+	checkQueryToStringHasFoo(t, query)
+}

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -268,3 +268,23 @@ func TestMockMatcherBasics(t *testing.T) {
 		t.Error("Next (iteration finished): %d", got)
 	}
 }
+
+func TestBitVecMatcherBasics(t *testing.T) {
+	bv := NewBitVector(0)
+	bv.Set(42)
+	bv.Set(43)
+	bv.Set(100)
+	matcher := NewBitVecMatcher(bv)
+	if got := matcher.Next(); got != 42 {
+		t.Error("Next: %d", got)
+	}
+	if got := matcher.GetDocID(); got != 42 {
+		t.Error("GetDocID: %d", got)
+	}
+	if got := matcher.Advance(50); got != 100 {
+		t.Error("Advance: %d", got)
+	}
+	if got := matcher.Next(); got != 0 {
+		t.Error("Next (iteration finished): %d", got)
+	}
+}

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -249,3 +249,22 @@ func TestLeafQueryBasics(t *testing.T) {
 	checkQueryEquals(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
+
+func TestMockMatcherBasics(t *testing.T) {
+	matcher := newMockMatcher([]int32{42, 43, 100}, []float32{1.5, 1.5, 1.5})
+	if got := matcher.Next(); got != 42 {
+		t.Error("Next: %d", got)
+	}
+	if got := matcher.GetDocID(); got != 42 {
+		t.Error("GetDocID: %d", got)
+	}
+	if score := matcher.Score(); score != 1.5 {
+		t.Error("Score: %f", score)
+	}
+	if got := matcher.Advance(50); got != 100 {
+		t.Error("Advance: %d", got)
+	}
+	if got := matcher.Next(); got != 0 {
+		t.Error("Next (iteration finished): %d", got)
+	}
+}


### PR DESCRIPTION
Refine Go bindings and add tests for many search classes, especially the Query classes.

Also fix argument handling for OpenIndexer and OpenIndexSearcher.