### PR TITLE
LUCY-284 Support Go host types as doc

### DIFF
--- a/go/build.go
+++ b/go/build.go
@@ -152,6 +152,7 @@ func specClasses(parcel *cfc.Parcel) {
 	searcherBinding.SpecMethod("Hits",
 		"Hits(query interface{}, offset uint32, numWanted uint32, sortSpec SortSpec) (Hits, error)")
 	searcherBinding.SpecMethod("Close", "Close() error")
+	searcherBinding.SpecMethod("", "ReadDoc(int32, interface{}) error")
 	searcherBinding.Register()
 
 	hitsBinding := cfc.NewGoClass(parcel, "Lucy::Search::Hits")

--- a/go/lucy/document.go
+++ b/go/lucy/document.go
@@ -39,12 +39,12 @@ func NewHitDoc(docID int32, score float32) HitDoc {
 	return WRAPHitDoc(unsafe.Pointer(retvalCF))
 }
 
-func fetchDocFields(d *C.lucy_Doc) *C.cfish_Hash {
+func fetchDocFields(d *C.lucy_Doc) map[string]interface{} {
 	ivars := C.lucy_Doc_IVARS(d)
 	fieldsID := uintptr(ivars.fields)
-	fieldsGo, ok := registry.fetch(fieldsID).(clownfish.Hash)
+	fieldsGo, ok := registry.fetch(fieldsID).(map[string]interface{})
 	if !ok {
 		panic(clownfish.NewErr(fmt.Sprintf("Failed to fetch doc %d from registry ", fieldsID)))
 	}
-	return (*C.cfish_Hash)(clownfish.Unwrap(fieldsGo, "fieldsGo"))
+	return fieldsGo
 }

--- a/go/lucy/document.go
+++ b/go/lucy/document.go
@@ -1,0 +1,34 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+/*
+#include "Lucy/Document/Doc.h"
+#include "Lucy/Document/HitDoc.h"
+*/
+import "C"
+import "unsafe"
+
+func NewDoc(docID int32) Doc {
+	retvalCF := C.lucy_Doc_new(nil, C.int32_t(docID))
+	return WRAPDoc(unsafe.Pointer(retvalCF))
+}
+
+func NewHitDoc(docID int32, score float32) HitDoc {
+	retvalCF := C.lucy_HitDoc_new(nil, C.int32_t(docID), C.float(score))
+	return WRAPHitDoc(unsafe.Pointer(retvalCF))
+}

--- a/go/lucy/document.go
+++ b/go/lucy/document.go
@@ -17,11 +17,17 @@
 package lucy
 
 /*
+#define C_LUCY_DOC
+
 #include "Lucy/Document/Doc.h"
 #include "Lucy/Document/HitDoc.h"
 */
 import "C"
 import "unsafe"
+import "fmt"
+
+import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
 
 func NewDoc(docID int32) Doc {
 	retvalCF := C.lucy_Doc_new(nil, C.int32_t(docID))
@@ -31,4 +37,14 @@ func NewDoc(docID int32) Doc {
 func NewHitDoc(docID int32, score float32) HitDoc {
 	retvalCF := C.lucy_HitDoc_new(nil, C.int32_t(docID), C.float(score))
 	return WRAPHitDoc(unsafe.Pointer(retvalCF))
+}
+
+func fetchDocFields(d *C.lucy_Doc) *C.cfish_Hash {
+	ivars := C.lucy_Doc_IVARS(d)
+	fieldsID := uintptr(ivars.fields)
+	fieldsGo, ok := registry.fetch(fieldsID).(clownfish.Hash)
+	if !ok {
+		panic(clownfish.NewErr(fmt.Sprintf("Failed to fetch doc %d from registry ", fieldsID)))
+	}
+	return (*C.cfish_Hash)(clownfish.Unwrap(fieldsGo, "fieldsGo"))
 }

--- a/go/lucy/index.go
+++ b/go/lucy/index.go
@@ -70,55 +70,95 @@ func (obj *IndexerIMP) Close() error {
 	return nil // TODO catch errors
 }
 
-func (obj *IndexerIMP) AddDoc(doc interface{}) error {
-	self := ((*C.lucy_Indexer)(unsafe.Pointer(obj.TOPTR())))
-	stockDoc := C.LUCY_Indexer_Get_Stock_Doc(self)
-	docFields := fetchDocFields(stockDoc)
+func (obj *IndexerIMP) addDocObj(doc Doc, boost float32) error {
+	self := (*C.lucy_Indexer)(clownfish.Unwrap(obj, "obj"))
+	d := (*C.lucy_Doc)(clownfish.Unwrap(doc, "doc"))
+	return clownfish.TrapErr(func() {
+		C.LUCY_Indexer_Add_Doc(self, d, C.float(boost))
+	})
+}
+
+func (obj *IndexerIMP) addMapAsDoc(doc map[string]interface{}, boost float32) error {
+	self := (*C.lucy_Indexer)(clownfish.Unwrap(obj, "obj"))
+	d := C.LUCY_Indexer_Get_Stock_Doc(self)
+	docFields := fetchDocFields(d)
+	for field := range docFields {
+		delete(docFields, field)
+	}
+	for key, value := range doc {
+		field, err := obj.findRealField(key)
+		if err != nil {
+			return err
+		}
+		docFields[field] = value
+	}
+	return clownfish.TrapErr(func() {
+		C.LUCY_Indexer_Add_Doc(self, d, C.float(boost))
+	})
+}
+
+func (obj *IndexerIMP) addStructAsDoc(doc interface{}, boost float32) error {
+	self := (*C.lucy_Indexer)(clownfish.Unwrap(obj, "obj"))
+	d := C.LUCY_Indexer_Get_Stock_Doc(self)
+	docFields := fetchDocFields(d)
 	for field := range docFields {
 		delete(docFields, field)
 	}
 
-	// TODO: Support map as doc in addition to struct as doc.
-
 	// Get reflection value and type for the supplied struct.
 	var docValue reflect.Value
+	var success bool
 	if reflect.ValueOf(doc).Kind() == reflect.Ptr {
 		temp := reflect.ValueOf(doc).Elem()
 		if temp.Kind() == reflect.Struct {
 			docValue = temp
+			success = true
 		}
 	}
-	if docValue == (reflect.Value{}) {
-		mess := fmt.Sprintf("Doc not struct pointer: %v",
-			reflect.TypeOf(doc))
+	if !success {
+		mess := fmt.Sprintf("Unexpected type for doc: %t", doc)
 		return clownfish.NewErr(mess)
 	}
-	docType := docValue.Type()
 
+	// Copy field values into stockDoc.
+	docType := docValue.Type()
 	for i := 0; i < docValue.NumField(); i++ {
 		field := docType.Field(i).Name
 		value := docValue.Field(i).String()
-		realField := obj.findRealField(field)
+		realField, err := obj.findRealField(field)
+		if err != nil {
+			return err
+		}
 		docFields[realField] = value
 	}
 
-	// TODO create an additional method AddDocWithBoost which allows the
-	// client to supply `boost`.
-	boost := 1.0
-	err := clownfish.TrapErr(func() {
-		C.LUCY_Indexer_Add_Doc(self, stockDoc, C.float(boost))
+	return clownfish.TrapErr(func() {
+		C.LUCY_Indexer_Add_Doc(self, d, C.float(boost))
 	})
-
-	return err
 }
 
-func (obj *IndexerIMP) findRealField(name string) string {
+func (obj *IndexerIMP) AddDoc(doc interface{}) error {
+	// TODO create an additional method AddDocWithBoost which allows the
+	// client to supply `boost`.
+	boost := float32(1.0)
+
+	if suppliedDoc, ok := doc.(Doc); ok {
+		return obj.addDocObj(suppliedDoc, boost)
+	} else if m, ok := doc.(map[string]interface{}); ok {
+		return obj.addMapAsDoc(m, boost)
+	} else {
+		return obj.addStructAsDoc(doc, boost)
+	}
+}
+
+func (obj *IndexerIMP) findRealField(name string) (string, error) {
 	self := ((*C.lucy_Indexer)(unsafe.Pointer(obj.TOPTR())))
 	if obj.fieldNames == nil {
 		obj.fieldNames = make(map[string]string)
 	}
-	f, ok := obj.fieldNames[name]
-	if !ok {
+	if field, ok := obj.fieldNames[name]; ok {
+		return field, nil
+	} else {
 		schema := C.LUCY_Indexer_Get_Schema(self)
 		fieldList := C.LUCY_Schema_All_Fields(schema)
 		defer C.cfish_dec_refcount(unsafe.Pointer(fieldList))
@@ -126,12 +166,12 @@ func (obj *IndexerIMP) findRealField(name string) string {
 			cfString := unsafe.Pointer(C.CFISH_Vec_Fetch(fieldList, C.size_t(i)))
 			field := clownfish.CFStringToGo(cfString)
 			if strings.EqualFold(name, field) {
-				f = field
 				obj.fieldNames[name] = field
+				return field, nil
 			}
 		}
 	}
-	return f
+	return "", clownfish.NewErr(fmt.Sprintf("Unknown field: '%v'", name))
 }
 
 func (obj *IndexerIMP) Commit() error {

--- a/go/lucy/index.go
+++ b/go/lucy/index.go
@@ -73,7 +73,7 @@ func (obj *IndexerIMP) Close() error {
 func (obj *IndexerIMP) AddDoc(doc interface{}) error {
 	self := ((*C.lucy_Indexer)(unsafe.Pointer(obj.TOPTR())))
 	stockDoc := C.LUCY_Indexer_Get_Stock_Doc(self)
-	docFields := (*C.cfish_Hash)(C.LUCY_Doc_Get_Fields(stockDoc))
+	docFields := fetchDocFields(stockDoc)
 	C.CFISH_Hash_Clear(docFields)
 
 	// TODO: Support map as doc in addition to struct as doc.

--- a/go/lucy/index_test.go
+++ b/go/lucy/index_test.go
@@ -1,0 +1,39 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "testing"
+
+func TestIndexerAddDoc(t *testing.T) {
+	schema := createTestSchema()
+	index := NewRAMFolder("")
+	indexer, _ := OpenIndexer(&OpenIndexerArgs{
+		Create: true,
+		Index:  index,
+		Schema: schema,
+	})
+	indexer.AddDoc(&testDoc{Content: "foo"})
+	indexer.AddDoc(map[string]interface{}{"content": "foo"})
+	doc := NewDoc(0)
+	doc.Store("content", "foo")
+	indexer.AddDoc(doc)
+	indexer.Commit()
+	searcher, _ := OpenIndexSearcher(index)
+	if got := searcher.DocFreq("content", "foo"); got != 3 {
+		t.Errorf("Didn't index all docs -- DocMax: %d", got)
+	}
+}

--- a/go/lucy/lucy.go
+++ b/go/lucy/lucy.go
@@ -249,11 +249,6 @@ func GOLUCY_RegexTokenizer_Tokenize_Utf8(rt *C.lucy_RegexTokenizer, str *C.char,
 	}
 }
 
-func NewDoc(docID int32) Doc {
-	retvalCF := C.lucy_Doc_new(nil, C.int32_t(docID))
-	return WRAPDoc(unsafe.Pointer(retvalCF))
-}
-
 //export GOLUCY_Doc_init
 func GOLUCY_Doc_init(d *C.lucy_Doc, fields unsafe.Pointer, docID C.int32_t) *C.lucy_Doc {
 	ivars := C.lucy_Doc_IVARS(d)

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -149,7 +149,7 @@ func (obj *HitsIMP) Next(hit interface{}) bool {
 	}
 	defer C.cfish_dec_refcount(unsafe.Pointer(docC))
 
-	fields := (*C.cfish_Hash)(unsafe.Pointer(C.LUCY_HitDoc_Get_Fields(docC)))
+	fields := fetchDocFields((*C.lucy_Doc)(unsafe.Pointer(docC)))
 	iterator := C.cfish_HashIter_new(fields)
 	defer C.cfish_dec_refcount(unsafe.Pointer(iterator))
 	for C.CFISH_HashIter_Next(iterator) {

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -17,6 +17,9 @@
 package lucy
 
 /*
+
+#define C_LUCY_HITS
+
 #include "Lucy/Search/Collector.h"
 #include "Lucy/Search/Collector/SortCollector.h"
 #include "Lucy/Search/Hits.h"
@@ -26,6 +29,7 @@ package lucy
 #include "Lucy/Search/ANDQuery.h"
 #include "Lucy/Search/ORQuery.h"
 #include "Lucy/Search/ANDMatcher.h"
+#include "Lucy/Search/MatchDoc.h"
 #include "Lucy/Search/ORMatcher.h"
 #include "Lucy/Search/SeriesMatcher.h"
 #include "Lucy/Search/SortRule.h"
@@ -46,9 +50,6 @@ float32_set(float *floats, size_t i, float value) {
 
 */
 import "C"
-import "fmt"
-import "reflect"
-import "strings"
 import "unsafe"
 
 import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
@@ -135,52 +136,36 @@ func (obj *PolySearcherIMP) Hits(query interface{}, offset uint32, numWanted uin
 	return doHits(obj, query, offset, numWanted, sortSpec)
 }
 
-func (obj *HitsIMP) Next(hit interface{}) bool {
-	self := ((*C.lucy_Hits)(unsafe.Pointer(obj.TOPTR())))
-	// TODO: accept a HitDoc object and populate score.
+type setScorer interface {
+	SetScore(float32)
+}
 
-	// Get reflection value and type for the supplied struct.
-	var hitValue reflect.Value
-	if reflect.ValueOf(hit).Kind() == reflect.Ptr {
-		temp := reflect.ValueOf(hit).Elem()
-		if temp.Kind() == reflect.Struct {
-			if temp.CanSet() {
-				hitValue = temp
-			}
-		}
-	}
-	if hitValue == (reflect.Value{}) {
-		mess := fmt.Sprintf("Arg not writeable struct pointer: %v",
-			reflect.TypeOf(hit))
-		obj.err = clownfish.NewErr(mess)
-		return false
-	}
+func (h *HitsIMP) Next(hit interface{}) bool {
+	self := (*C.lucy_Hits)(clownfish.Unwrap(h, "h"))
+	ivars := C.lucy_Hits_IVARS(self)
+	matchDoc := (*C.lucy_MatchDoc)(unsafe.Pointer(
+		C.CFISH_Vec_Fetch(ivars.match_docs, C.size_t(ivars.offset))))
+	ivars.offset += 1
 
-	var docC *C.lucy_HitDoc
-	errCallingNext := clownfish.TrapErr(func() {
-		docC = C.LUCY_Hits_Next(self)
-	})
-	if errCallingNext != nil {
-		obj.err = errCallingNext
+	if matchDoc == nil {
+		// Bail if there aren't any more *captured* hits.  (There may be
+		// more total hits.)
 		return false
-	}
-	if docC == nil {
-		return false
-	}
-	defer C.cfish_dec_refcount(unsafe.Pointer(docC))
-
-	fields := fetchDocFields((*C.lucy_Doc)(unsafe.Pointer(docC)))
-	for key, val := range fields {
-		stringVal := val.(string) // TODO type switch
-		match := func(name string) bool {
-			return strings.EqualFold(key, name)
+	} else {
+		// Lazily fetch HitDoc, set score.
+		searcher := clownfish.WRAPAny(unsafe.Pointer(C.cfish_incref(
+			unsafe.Pointer(ivars.searcher)))).(Searcher)
+		docID := int32(C.LUCY_MatchDoc_Get_Doc_ID(matchDoc))
+		err := searcher.ReadDoc(docID, hit)
+		if err != nil {
+			h.err = err
+			return false
 		}
-		structField := hitValue.FieldByNameFunc(match)
-		if structField != (reflect.Value{}) {
-			structField.SetString(stringVal)
+		if ss, ok := hit.(setScorer); ok {
+			ss.SetScore(float32(C.LUCY_MatchDoc_Get_Score(matchDoc)))
 		}
+		return true
 	}
-	return true
 }
 
 func (obj *HitsIMP) Error() error {

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -150,19 +150,14 @@ func (obj *HitsIMP) Next(hit interface{}) bool {
 	defer C.cfish_dec_refcount(unsafe.Pointer(docC))
 
 	fields := fetchDocFields((*C.lucy_Doc)(unsafe.Pointer(docC)))
-	iterator := C.cfish_HashIter_new(fields)
-	defer C.cfish_dec_refcount(unsafe.Pointer(iterator))
-	for C.CFISH_HashIter_Next(iterator) {
-		keyC := C.CFISH_HashIter_Get_Key(iterator)
-		valC := C.CFISH_HashIter_Get_Value(iterator)
-		key := clownfish.CFStringToGo(unsafe.Pointer(keyC))
-		val := clownfish.CFStringToGo(unsafe.Pointer(valC))
+	for key, val := range fields {
+		stringVal := val.(string) // TODO type switch
 		match := func(name string) bool {
 			return strings.EqualFold(key, name)
 		}
 		structField := hitValue.FieldByNameFunc(match)
 		if structField != (reflect.Value{}) {
-			structField.SetString(val)
+			structField.SetString(stringVal)
 		}
 	}
 	return true

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -623,6 +623,36 @@ func TestIndexSearcherTopDocs(t *testing.T) {
 	}
 }
 
+func TestIndexSearcherReadDoc(t *testing.T) {
+	index := createTestIndex("a", "b")
+	searcher, _ := OpenIndexSearcher(index)
+	docDoc := NewHitDoc(0, -1.0)
+	docStruct := &simpleTestDoc{}
+	docMap := make(map[string]interface{})
+	var err error
+	err = searcher.ReadDoc(2, docDoc)
+	if err != nil {
+		t.Errorf("ReadDoc failed with HitDoc: %v", err)
+	}
+	err = searcher.ReadDoc(2, docStruct)
+	if err != nil {
+		t.Errorf("ReadDoc failed with struct: %v", err)
+	}
+	err = searcher.ReadDoc(2, docMap)
+	if err != nil {
+		t.Errorf("ReadDoc failed with map: %v", err)
+	}
+	if docDoc.Extract("content").(string) != "b" {
+		t.Error("Next with Doc object yielded bad data")
+	}
+	if docStruct.Content != "b" {
+		t.Error("Next with struct yielded bad data")
+	}
+	if docMap["content"].(string) != "b" {
+		t.Error("Next with map yielded bad data")
+	}
+}
+
 func TestMatchDocBasics(t *testing.T) {
 	matchDoc := NewMatchDoc(0, 1.0, nil)
 	matchDoc.SetDocID(42)

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -438,6 +438,30 @@ func TestHitsBasics(t *testing.T) {
 	}
 }
 
+func TestHitsNext(t *testing.T) {
+	index := createTestIndex("a x", "a y", "a z", "b")
+	searcher, _ := OpenIndexSearcher(index)
+	hits, _ := searcher.Hits("a", 0, 10, nil)
+	docDoc := NewHitDoc(0, -1.0)
+	docStruct := &simpleTestDoc{}
+	docMap := make(map[string]interface{})
+	if !hits.Next(docDoc) || !hits.Next(docStruct) || !hits.Next(docMap) {
+		t.Errorf("Hits.Next returned false: %v", hits.Error())
+	}
+	if hits.Next(&simpleTestDoc{}) {
+		t.Error("Hits iterator should be exhausted");
+	}
+	if docDoc.Extract("content").(string) != "a x" {
+		t.Error("Next with Doc object yielded bad data")
+	}
+	if docStruct.Content != "a y" {
+		t.Error("Next with struct yielded bad data")
+	}
+	if docMap["content"].(string) != "a z" {
+		t.Error("Next with map yielded bad data")
+	}
+}
+
 func TestSortSpecBasics(t *testing.T) {
 	folder := NewRAMFolder("")
 	schema := NewSchema()


### PR DESCRIPTION
Support the following types as documents in Go bindings:

*   Doc objects wrapped in Go bindings
*   `map[string]interface{}`
*   Go structs (field names matched case-insensitively)