### PR TITLE
LUCY-285 Run core tests under Go

### DIFF
--- a/core/Lucy/Test/Analysis/TestNormalizer.c
+++ b/core/Lucy/Test/Analysis/TestNormalizer.c
@@ -74,6 +74,11 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
 static void
 test_normalization(TestBatchRunner *runner) {
     FSFolder *modules_folder = TestUtils_modules_folder();
+    if (modules_folder == NULL) {
+        SKIP(runner, 13, "Can't locate test data");
+        return;
+    }
+
     String *path = Str_newf("unicode/utf8proc/tests.json");
     Vector *tests = (Vector*)Json_slurp_json((Folder*)modules_folder, path);
     if (!tests) { RETHROW(Err_get_error()); }

--- a/core/Lucy/Test/Analysis/TestSnowballStemmer.c
+++ b/core/Lucy/Test/Analysis/TestSnowballStemmer.c
@@ -64,6 +64,11 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
 static void
 test_stemming(TestBatchRunner *runner) {
     FSFolder *modules_folder = TestUtils_modules_folder();
+    if (modules_folder == NULL) {
+        SKIP(runner, 150, "Can't locate test data");
+        return;
+    }
+
     String *path = Str_newf("analysis/snowstem/source/test/tests.json");
     Hash *tests = (Hash*)Json_slurp_json((Folder*)modules_folder, path);
     if (!tests) { RETHROW(Err_get_error()); }

--- a/core/Lucy/Test/Analysis/TestStandardTokenizer.c
+++ b/core/Lucy/Test/Analysis/TestStandardTokenizer.c
@@ -95,22 +95,27 @@ test_tokenizer(TestBatchRunner *runner) {
     DECREF(got);
 
     FSFolder *modules_folder = TestUtils_modules_folder();
-    String *path = Str_newf("unicode/ucd/WordBreakTest.json");
-    Vector *tests = (Vector*)Json_slurp_json((Folder*)modules_folder, path);
-    if (!tests) { RETHROW(Err_get_error()); }
-
-    for (uint32_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
-        Hash *test = (Hash*)Vec_Fetch(tests, i);
-        String *text = (String*)Hash_Fetch_Utf8(test, "text", 4);
-        Vector *wanted = (Vector*)Hash_Fetch_Utf8(test, "words", 5);
-        Vector *got = StandardTokenizer_Split(tokenizer, text);
-        TEST_TRUE(runner, Vec_Equals(wanted, (Obj*)got), "UCD test #%d", i + 1);
-        DECREF(got);
+    if (modules_folder == NULL) {
+        SKIP(runner, 1372, "Can't locate test data");
     }
+    else {
+        String *path = Str_newf("unicode/ucd/WordBreakTest.json");
+        Vector *tests = (Vector*)Json_slurp_json((Folder*)modules_folder, path);
+        if (!tests) { RETHROW(Err_get_error()); }
 
-    DECREF(tests);
-    DECREF(modules_folder);
-    DECREF(path);
+        for (uint32_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
+            Hash *test = (Hash*)Vec_Fetch(tests, i);
+            String *text = (String*)Hash_Fetch_Utf8(test, "text", 4);
+            Vector *wanted = (Vector*)Hash_Fetch_Utf8(test, "words", 5);
+            Vector *got = StandardTokenizer_Split(tokenizer, text);
+            TEST_TRUE(runner, Vec_Equals(wanted, (Obj*)got), "UCD test #%d", i + 1);
+            DECREF(got);
+        }
+
+        DECREF(tests);
+        DECREF(modules_folder);
+        DECREF(path);
+    }
 
     DECREF(tokenizer);
 }

--- a/core/Lucy/Test/TestUtils.c
+++ b/core/Lucy/Test/TestUtils.c
@@ -180,7 +180,6 @@ TestUtils_modules_folder() {
         DECREF(modules_folder);
     }
 
-    THROW(ERR, "Can't open modules folder");
-    UNREACHABLE_RETURN(FSFolder*);
+    return NULL;
 }
 

--- a/core/Lucy/Test/TestUtils.cfh
+++ b/core/Lucy/Test/TestUtils.cfh
@@ -66,8 +66,10 @@ inert class Lucy::Test::TestUtils  {
                   Vector *expected, const char *message);
 
     /** Return the "modules" folder.
+     *
+     * If the folder cannot be found, return NULL.
      */
-    inert FSFolder*
+    inert incremented nullable FSFolder*
     modules_folder();
 }
 

--- a/go/lucy/lucy.go
+++ b/go/lucy/lucy.go
@@ -28,6 +28,7 @@ package lucy
 #define C_LUCY_POLYDOCREADER
 
 #include "lucy_parcel.h"
+#include "testlucy_parcel.h"
 #include "Lucy/Analysis/RegexTokenizer.h"
 #include "Lucy/Document/Doc.h"
 #include "Lucy/Index/DocReader.h"
@@ -196,6 +197,7 @@ var registry *objRegistry
 func init() {
 	C.GOLUCY_glue_exported_symbols()
 	C.lucy_bootstrap_parcel()
+	C.testlucy_bootstrap_parcel()
 	registry = newObjRegistry(16)
 	initWRAP()
 }

--- a/go/lucy/test.go
+++ b/go/lucy/test.go
@@ -1,0 +1,30 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+/*
+#include "Lucy/Test.h"
+*/
+import "C"
+import "unsafe"
+
+import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
+func createTestSuite() clownfish.TestSuite {
+	ts := C.testlucy_Test_create_test_suite()
+	return clownfish.WRAPAny(unsafe.Pointer(ts)).(clownfish.TestSuite)
+}

--- a/go/lucy/test_test.go
+++ b/go/lucy/test_test.go
@@ -1,0 +1,30 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lucy
+
+import "testing"
+
+import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
+
+func TestRunCoreTests(t *testing.T) {
+	suite := createTestSuite()
+	formatter := clownfish.NewTestFormatterCF()
+	success := suite.RunAllBatches(formatter)
+	if !success {
+		t.Error("Core tests failed")
+	}
+}


### PR DESCRIPTION
Run the core tests under the Go bindings, just as we do under other host bindings.

Skip Analysis tests when the test data can't be found.