### PR TITLE
LUCY-292 Fix refcount order when overwriting.

### DIFF
--- a/core/Lucy/Highlight/Highlighter.c
+++ b/core/Lucy/Highlight/Highlighter.c
@@ -103,15 +103,17 @@ Highlighter_Highlight_IMP(Highlighter *self, String *text) {
 void
 Highlighter_Set_Pre_Tag_IMP(Highlighter *self, String *pre_tag) {
     HighlighterIVARS *const ivars = Highlighter_IVARS(self);
-    DECREF(ivars->pre_tag);
+    String *temp = ivars->pre_tag;
     ivars->pre_tag = Str_Clone(pre_tag);
+    DECREF(temp);
 }
 
 void
 Highlighter_Set_Post_Tag_IMP(Highlighter *self, String *post_tag) {
     HighlighterIVARS *const ivars = Highlighter_IVARS(self);
-    DECREF(ivars->post_tag);
+    String *temp = ivars->post_tag;
     ivars->post_tag = Str_Clone(post_tag);
+    DECREF(temp);
 }
 
 String*

--- a/core/Lucy/Index/IndexManager.c
+++ b/core/Lucy/Index/IndexManager.c
@@ -325,8 +325,9 @@ IxManager_Make_Snapshot_Read_Lock_IMP(IndexManager *self,
 void
 IxManager_Set_Folder_IMP(IndexManager *self, Folder *folder) {
     IndexManagerIVARS *const ivars = IxManager_IVARS(self);
-    DECREF(ivars->folder);
+    Folder *temp = ivars->folder;
     ivars->folder = (Folder*)INCREF(folder);
+    DECREF(temp);
 }
 
 Folder*

--- a/core/Lucy/Index/PolyLexicon.c
+++ b/core/Lucy/Index/PolyLexicon.c
@@ -134,8 +134,9 @@ PolyLex_Next_IMP(PolyLexicon *self) {
             || Obj_Compare_To(ivars->term, candidate) != 0
            ) {
             // Succeed if the next item in the queue has a different term.
-            DECREF(ivars->term);
+            Obj *temp = ivars->term;
             ivars->term = Obj_Clone(candidate);
+            DECREF(temp);
             return true;
         }
         else {

--- a/core/Lucy/Index/SegWriter.c
+++ b/core/Lucy/Index/SegWriter.c
@@ -222,8 +222,9 @@ SegWriter_Add_Data_Writer_IMP(SegWriter *self, DataWriter *writer) {
 void
 SegWriter_Set_Del_Writer_IMP(SegWriter *self, DeletionsWriter *del_writer) {
     SegWriterIVARS *const ivars = SegWriter_IVARS(self);
-    DECREF(ivars->del_writer);
+    DeletionsWriter *temp = ivars->del_writer;
     ivars->del_writer = (DeletionsWriter*)INCREF(del_writer);
+    DECREF(temp);
 }
 
 DeletionsWriter*

--- a/core/Lucy/Index/Snapshot.c
+++ b/core/Lucy/Index/Snapshot.c
@@ -94,8 +94,9 @@ Snapshot_Num_Entries_IMP(Snapshot *self) {
 void
 Snapshot_Set_Path_IMP(Snapshot *self, String *path) {
     SnapshotIVARS *const ivars = Snapshot_IVARS(self);
-    DECREF(ivars->path);
+    String *temp = ivars->path;
     ivars->path = path ? Str_Clone(path) : NULL;
+    DECREF(temp);
 }
 
 String*

--- a/core/Lucy/Index/TermStepper.c
+++ b/core/Lucy/Index/TermStepper.c
@@ -53,8 +53,9 @@ TermStepper_Get_Value_IMP(TermStepper *self) {
 void
 TermStepper_Set_Value_IMP(TermStepper *self, Obj *value) {
     TermStepperIVARS *const ivars = TermStepper_IVARS(self);
-    DECREF(ivars->value);
+    Obj *temp = ivars->value;
     ivars->value = value ? INCREF(value) : NULL;
+    DECREF(temp);
 }
 
 

--- a/core/Lucy/Search/Collector.c
+++ b/core/Lucy/Search/Collector.c
@@ -44,15 +44,17 @@ Coll_Destroy_IMP(Collector *self) {
 void
 Coll_Set_Reader_IMP(Collector *self, SegReader *reader) {
     CollectorIVARS *const ivars = Coll_IVARS(self);
-    DECREF(ivars->reader);
+    SegReader *temp = ivars->reader;
     ivars->reader = (SegReader*)INCREF(reader);
+    DECREF(temp);
 }
 
 void
 Coll_Set_Matcher_IMP(Collector *self, Matcher *matcher) {
     CollectorIVARS *const ivars = Coll_IVARS(self);
-    DECREF(ivars->matcher);
+    Matcher *temp = ivars->matcher;
     ivars->matcher = (Matcher*)INCREF(matcher);
+    DECREF(temp);
 }
 
 void

--- a/core/Lucy/Search/MatchDoc.c
+++ b/core/Lucy/Search/MatchDoc.c
@@ -92,8 +92,9 @@ MatchDoc_Set_Score_IMP(MatchDoc *self, float score) {
 void
 MatchDoc_Set_Values_IMP(MatchDoc *self, Vector *values) {
     MatchDocIVARS *const ivars = MatchDoc_IVARS(self);
-    DECREF(ivars->values);
+    Vector *temp = ivars->values;
     ivars->values = (Vector*)INCREF(values);
+    DECREF(temp);
 }
 
 

--- a/core/Lucy/Search/PolyQuery.c
+++ b/core/Lucy/Search/PolyQuery.c
@@ -57,8 +57,9 @@ PolyQuery_Add_Child_IMP(PolyQuery *self, Query *query) {
 void
 PolyQuery_Set_Children_IMP(PolyQuery *self, Vector *children) {
     PolyQueryIVARS *const ivars = PolyQuery_IVARS(self);
-    DECREF(ivars->children);
+    Vector *temp = ivars->children;
     ivars->children = (Vector*)INCREF(children);
+    DECREF(temp);
 }
 
 Vector*

--- a/core/Lucy/Search/QueryParser/ParserElem.c
+++ b/core/Lucy/Search/QueryParser/ParserElem.c
@@ -44,9 +44,9 @@ ParserElem_Destroy_IMP(ParserElem *self) {
 void
 ParserElem_Set_Value_IMP(ParserElem *self, Obj *value) {
     ParserElemIVARS *const ivars = ParserElem_IVARS(self);
-    Obj *new_value = INCREF(value);
-    DECREF(ivars->value);
-    ivars->value = new_value;
+    Obj *temp = ivars->value;
+    ivars->value = INCREF(value);
+    DECREF(temp);
 }
 
 Obj*

--- a/core/Lucy/Search/TopDocs.c
+++ b/core/Lucy/Search/TopDocs.c
@@ -75,8 +75,9 @@ TopDocs_Get_Total_Hits_IMP(TopDocs *self) {
 void
 TopDocs_Set_Match_Docs_IMP(TopDocs *self, Vector *match_docs) {
     TopDocsIVARS *const ivars = TopDocs_IVARS(self);
-    DECREF(ivars->match_docs);
+    Vector *temp = ivars->match_docs;
     ivars->match_docs = (Vector*)INCREF(match_docs);
+    DECREF(temp);
 }
 void
 TopDocs_Set_Total_Hits_IMP(TopDocs *self, uint32_t total_hits) {

--- a/core/Lucy/Store/FileHandle.c
+++ b/core/Lucy/Store/FileHandle.c
@@ -55,8 +55,9 @@ FH_Grow_IMP(FileHandle *self, int64_t length) {
 void
 FH_Set_Path_IMP(FileHandle *self, String *path) {
     FileHandleIVARS *const ivars = FH_IVARS(self);
-    DECREF(ivars->path);
+    String *temp = ivars->path;
     ivars->path = Str_Clone(path);
+    DECREF(temp);
 }
 
 String*

--- a/core/Lucy/Store/Folder.c
+++ b/core/Lucy/Store/Folder.c
@@ -403,8 +403,9 @@ Folder_Get_Path_IMP(Folder *self) {
 void
 Folder_Set_Path_IMP(Folder *self, String *path) {
     FolderIVARS *const ivars = Folder_IVARS(self);
-    DECREF(ivars->path);
+    String *temp = ivars->path;
     ivars->path = Str_Clone(path);
+    DECREF(temp);
 }
 
 void

--- a/core/Lucy/Store/InStream.c
+++ b/core/Lucy/Store/InStream.c
@@ -141,8 +141,9 @@ InStream_Reopen_IMP(InStream *self, String *filename, int64_t offset,
     InStreamIVARS *const ovars = InStream_IVARS(other);
     InStream_do_open(other, (Obj*)ivars->file_handle);
     if (filename != NULL) {
-        DECREF(ovars->filename);
+        String *temp = ovars->filename;
         ovars->filename = Str_Clone(filename);
+        DECREF(temp);
     }
     ovars->offset = offset;
     ovars->len    = len;


### PR DESCRIPTION
When there's a possibility that a recounted value is overwriting itself,
delay the decref until after any incref so that there is no way the
refcount can fall to 0 prior to the incref.