### PR TITLE
LUCY-294 Ensure nul-terminated C strings in test code.

### DIFF
--- a/core/Lucy/Test/Analysis/TestNormalizer.c
+++ b/core/Lucy/Test/Analysis/TestNormalizer.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
+
 #define C_TESTLUCY_TESTNORMALIZER
 #define C_LUCY_NORMALIZER
 #define TESTLUCY_USE_SHORT_NAMES
@@ -98,13 +100,17 @@ test_normalization(TestBatchRunner *runner) {
             String *word = (String*)Vec_Fetch(words, j);
             Vector *got  = Normalizer_Split(normalizer, word);
             String *norm = (String*)Vec_Fetch(got, 0);
+            char   *fstr = Str_To_Utf8(form);
+            char   *wstr = Str_To_Utf8(word);
             TEST_TRUE(runner,
                       norm
                       && Str_is_a(norm, STRING)
                       && Str_Equals(norm, Vec_Fetch(norms, j)),
-                      "Normalize %s %d %d: %s", Str_Get_Ptr8(form),
-                      case_fold, strip_accents, Str_Get_Ptr8(word)
+                      "Normalize %s %d %d: %s", fstr,
+                      case_fold, strip_accents, wstr
                      );
+            free(fstr);
+            free(wstr);
             DECREF(got);
         }
         DECREF(normalizer);
@@ -139,7 +145,9 @@ test_utf8proc_normalization(TestBatchRunner *runner) {
             if (!json) {
                 json = Str_newf("[failed to encode]");
             }
-            FAIL(runner, "Failed to normalize: %s", Str_Get_Ptr8(json));
+            char *str = Str_To_Utf8(json);
+            FAIL(runner, "Failed to normalize: %s", str);
+            free(str);
             DECREF(json);
             DECREF(source);
             return;

--- a/core/Lucy/Test/Analysis/TestSnowballStemmer.c
+++ b/core/Lucy/Test/Analysis/TestSnowballStemmer.c
@@ -76,22 +76,26 @@ test_stemming(TestBatchRunner *runner) {
     HashIterator *iter = HashIter_new(tests);
     while (HashIter_Next(iter)) {
         String *iso       = HashIter_Get_Key(iter);
+        char   *iso_str   = Str_To_Utf8(iso);
         Hash   *lang_data = (Hash*)HashIter_Get_Value(iter);
         Vector *words = (Vector*)Hash_Fetch_Utf8(lang_data, "words", 5);
         Vector *stems = (Vector*)Hash_Fetch_Utf8(lang_data, "stems", 5);
         SnowballStemmer *stemmer = SnowStemmer_new(iso);
         for (uint32_t i = 0, max = Vec_Get_Size(words); i < max; i++) {
             String *word  = (String*)Vec_Fetch(words, i);
+            char   *wstr  = Str_To_Utf8(word);
             Vector *got   = SnowStemmer_Split(stemmer, word);
             String *stem  = (String*)Vec_Fetch(got, 0);
             TEST_TRUE(runner,
                       stem
                       && Str_is_a(stem, STRING)
                       && Str_Equals(stem, Vec_Fetch(stems, i)),
-                      "Stem %s: %s", Str_Get_Ptr8(iso), Str_Get_Ptr8(word)
+                      "Stem %s: %s", iso_str, wstr
                      );
+            free(wstr);
             DECREF(got);
         }
+        free(iso_str);
         DECREF(stemmer);
     }
     DECREF(iter);

--- a/core/Lucy/Test/Analysis/TestStandardTokenizer.c
+++ b/core/Lucy/Test/Analysis/TestStandardTokenizer.c
@@ -62,35 +62,45 @@ test_tokenizer(TestBatchRunner *runner) {
                               "/");
     Vector *got = StandardTokenizer_Split(tokenizer, word);
     String *token = (String*)Vec_Fetch(got, 0);
+    char   *token_str = Str_To_Utf8(token);
     TEST_TRUE(runner,
               token
               && Str_is_a(token, STRING)
               && Str_Equals_Utf8(token, "tha\xcc\x82t's", 8),
-              "Token: %s", Str_Get_Ptr8(token));
+              "Token: %s", token_str);
+    free(token_str);
     token = (String*)Vec_Fetch(got, 1);
+    token_str = Str_To_Utf8(token);
     TEST_TRUE(runner,
               token
               && Str_is_a(token, STRING)
               && Str_Equals_Utf8(token, "1,02\xC2\xADZ4.38", 11),
-              "Token: %s", Str_Get_Ptr8(token));
+              "Token: %s", token_str);
+    free(token_str);
     token = (String*)Vec_Fetch(got, 2);
+    token_str = Str_To_Utf8(token);
     TEST_TRUE(runner,
               token
               && Str_is_a(token, STRING)
               && Str_Equals_Utf8(token, "\xE0\xB8\x81\xC2\xAD\xC2\xAD", 7),
-              "Token: %s", Str_Get_Ptr8(token));
+              "Token: %s", token_str);
+    free(token_str);
     token = (String*)Vec_Fetch(got, 3);
+    token_str = Str_To_Utf8(token);
     TEST_TRUE(runner,
               token
               && Str_is_a(token, STRING)
               && Str_Equals_Utf8(token, "\xF0\xA0\x80\x80", 4),
-              "Token: %s", Str_Get_Ptr8(token));
+              "Token: %s", token_str);
+    free(token_str);
     token = (String*)Vec_Fetch(got, 4);
+    token_str = Str_To_Utf8(token);
     TEST_TRUE(runner,
               token
               && Str_is_a(token, STRING)
               && Str_Equals_Utf8(token, "a", 1),
-              "Token: %s", Str_Get_Ptr8(token));
+              "Token: %s", token_str);
+    free(token_str);
     DECREF(got);
 
     FSFolder *modules_folder = TestUtils_modules_folder();

--- a/core/Lucy/Test/Highlight/TestHighlighter.c
+++ b/core/Lucy/Test/Highlight/TestHighlighter.c
@@ -71,9 +71,11 @@ test_Raw_Excerpt(TestBatchRunner *runner, Searcher *searcher, Obj *query) {
     DECREF(spans);
     raw_excerpt = Highlighter_Raw_Excerpt(highlighter, field_val, &top,
                                           heat_map);
+    char *raw_str = Str_To_Utf8(raw_excerpt);
     TEST_TRUE(runner,
               Str_Equals_Utf8(raw_excerpt, "Ook.", 4),
-              "Raw_Excerpt at top %s", Str_Get_Ptr8(raw_excerpt));
+              "Raw_Excerpt at top %s", raw_str);
+    free(raw_str);
     TEST_TRUE(runner,
               top == 0,
               "top is 0");

--- a/core/Lucy/Test/Plan/TestFieldMisc.c
+++ b/core/Lucy/Test/Plan/TestFieldMisc.c
@@ -123,19 +123,20 @@ S_add_doc(Indexer *indexer, String *field_name) {
 static void
 S_check(TestBatchRunner *runner, RAMFolder *folder, String *field,
         String *query_text, uint32_t expected_num_hits) {
+    char *field_str  = Str_To_Utf8(field);
     TermQuery *query = TermQuery_new(field, (Obj*)query_text);
     IndexSearcher *searcher = IxSearcher_new((Obj*)folder);
     Hits *hits = IxSearcher_Hits(searcher, (Obj*)query, 0, 10, NULL);
 
     TEST_TRUE(runner, Hits_Total_Hits(hits) == expected_num_hits,
-              "%s correct num hits", Str_Get_Ptr8(field));
+              "%s correct num hits", field_str);
 
     // Don't check the contents of the hit if there aren't any.
     if (expected_num_hits) {
         HitDoc *hit = Hits_Next(hits);
         String *value = (String*)HitDoc_Extract(hit, field);
         TEST_TRUE(runner, Str_Equals(united_states_str, (Obj*)value),
-                  "%s correct doc returned", Str_Get_Ptr8(field));
+                  "%s correct doc returned", field_str);
         DECREF(value);
         DECREF(hit);
     }
@@ -143,6 +144,7 @@ S_check(TestBatchRunner *runner, RAMFolder *folder, String *field,
     DECREF(hits);
     DECREF(searcher);
     DECREF(query);
+    free(field_str);
 }
 
 static void

--- a/core/Lucy/Test/Search/TestQueryParserLogic.c
+++ b/core/Lucy/Test/Search/TestQueryParserLogic.c
@@ -19,6 +19,7 @@
 #define TESTLUCY_USE_SHORT_NAMES
 #include "Lucy/Util/ToolSet.h"
 #include <string.h>
+#include <stdlib.h>
 
 #include "Clownfish/TestHarness/TestBatchRunner.h"
 #include "Lucy/Test.h"
@@ -904,11 +905,13 @@ TestQPLogic_Run_IMP(TestQueryParserLogic *self, TestBatchRunner *runner) {
         Query *tree     = QParser_Tree(or_parser, test_case->query_string);
         Query *parsed   = QParser_Parse(or_parser, test_case->query_string);
         Hits  *hits     = IxSearcher_Hits(searcher, (Obj*)parsed, 0, 10, NULL);
+        char  *qstr     = Str_To_Utf8(test_case->query_string);
 
         TEST_TRUE(runner, Query_Equals(tree, (Obj*)test_case->tree),
-                  "tree() OR   %s", Str_Get_Ptr8(test_case->query_string));
+                  "tree() OR   %s", qstr);
         TEST_INT_EQ(runner, Hits_Total_Hits(hits), test_case->num_hits,
-                    "hits: OR   %s", Str_Get_Ptr8(test_case->query_string));
+                    "hits: OR   %s", qstr);
+        free(qstr);
         DECREF(hits);
         DECREF(parsed);
         DECREF(tree);
@@ -923,11 +926,13 @@ TestQPLogic_Run_IMP(TestQueryParserLogic *self, TestBatchRunner *runner) {
         Query *tree     = QParser_Tree(and_parser, test_case->query_string);
         Query *parsed   = QParser_Parse(and_parser, test_case->query_string);
         Hits  *hits     = IxSearcher_Hits(searcher, (Obj*)parsed, 0, 10, NULL);
+        char  *qstr     = Str_To_Utf8(test_case->query_string);
 
         TEST_TRUE(runner, Query_Equals(tree, (Obj*)test_case->tree),
-                  "tree() AND   %s", Str_Get_Ptr8(test_case->query_string));
+                  "tree() AND   %s", qstr);
         TEST_INT_EQ(runner, Hits_Total_Hits(hits), test_case->num_hits,
-                    "hits: AND   %s", Str_Get_Ptr8(test_case->query_string));
+                    "hits: AND   %s", qstr);
+        free(qstr);
         DECREF(hits);
         DECREF(parsed);
         DECREF(tree);
@@ -942,6 +947,7 @@ TestQPLogic_Run_IMP(TestQueryParserLogic *self, TestBatchRunner *runner) {
         String *qstring = test_case->tree
                           ? Query_To_String(test_case->tree)
                           : Str_new_from_trusted_utf8("(NULL)", 6);
+        char  *qstr = Str_To_Utf8(qstring);
         Query *tree = test_case->tree;
         Query *wanted = test_case->expanded;
         Query *pruned   = QParser_Prune(or_parser, tree);
@@ -949,12 +955,13 @@ TestQPLogic_Run_IMP(TestQueryParserLogic *self, TestBatchRunner *runner) {
         Hits  *hits;
 
         TEST_TRUE(runner, Query_Equals(pruned, (Obj*)wanted),
-                  "prune()   %s", Str_Get_Ptr8(qstring));
+                  "prune()   %s", qstr);
         expanded = QParser_Expand(or_parser, pruned);
         hits = IxSearcher_Hits(searcher, (Obj*)expanded, 0, 10, NULL);
         TEST_INT_EQ(runner, Hits_Total_Hits(hits), test_case->num_hits,
-                    "hits:    %s", Str_Get_Ptr8(qstring));
+                    "hits:    %s", qstr);
 
+        free(qstr);
         DECREF(hits);
         DECREF(expanded);
         DECREF(pruned);

--- a/core/Lucy/Test/Search/TestQueryParserSyntax.c
+++ b/core/Lucy/Test/Search/TestQueryParserSyntax.c
@@ -19,6 +19,7 @@
 #define TESTLUCY_USE_SHORT_NAMES
 #include "Lucy/Util/ToolSet.h"
 #include <string.h>
+#include <stdlib.h>
 
 #include "Clownfish/Boolean.h"
 #include "Clownfish/TestHarness/TestBatchRunner.h"
@@ -401,13 +402,15 @@ test_query_parser_syntax(TestBatchRunner *runner) {
         Query *expanded = QParser_Expand_Leaf(qparser, ivars->tree);
         Query *parsed   = QParser_Parse(qparser, ivars->query_string);
         Hits  *hits     = IxSearcher_Hits(searcher, (Obj*)parsed, 0, 10, NULL);
+        char  *qstr     = Str_To_Utf8(ivars->query_string);
 
         TEST_TRUE(runner, Query_Equals(tree, (Obj*)ivars->tree),
-                  "tree()    %s", Str_Get_Ptr8(ivars->query_string));
+                  "tree()    %s", qstr);
         TEST_TRUE(runner, Query_Equals(expanded, (Obj*)ivars->expanded),
-                  "expand_leaf()    %s", Str_Get_Ptr8(ivars->query_string));
+                  "expand_leaf()    %s", qstr);
         TEST_INT_EQ(runner, Hits_Total_Hits(hits), ivars->num_hits,
-                    "hits:    %s", Str_Get_Ptr8(ivars->query_string));
+                    "hits:    %s", qstr);
+        free(qstr);
         DECREF(hits);
         DECREF(parsed);
         DECREF(expanded);
@@ -422,11 +425,13 @@ test_query_parser_syntax(TestBatchRunner *runner) {
         Query *tree   = QParser_Tree(qparser, ivars->query_string);
         Query *parsed = QParser_Parse(qparser, ivars->query_string);
         Hits  *hits   = IxSearcher_Hits(searcher, (Obj*)parsed, 0, 10, NULL);
+        char  *qstr   = Str_To_Utf8(ivars->query_string);
 
         TEST_TRUE(runner, Query_Equals(tree, (Obj*)ivars->tree),
-                  "tree()    %s", Str_Get_Ptr8(ivars->query_string));
+                  "tree()    %s", qstr);
         TEST_INT_EQ(runner, Hits_Total_Hits(hits), ivars->num_hits,
-                    "hits:    %s", Str_Get_Ptr8(ivars->query_string));
+                    "hits:    %s", qstr);
+        free(qstr);
         DECREF(hits);
         DECREF(parsed);
         DECREF(tree);

--- a/core/Lucy/Test/Store/TestCompoundFileWriter.c
+++ b/core/Lucy/Test/Store/TestCompoundFileWriter.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
+
 #define TESTLUCY_USE_SHORT_NAMES
 #include "Lucy/Util/ToolSet.h"
 
@@ -131,8 +133,10 @@ test_offsets(TestBatchRunner *runner) {
         int64_t offs   = Json_obj_to_i64(offset);
         if (offs % 8 != 0) {
             offsets_ok = false;
+            char *str = Str_To_Utf8(file);
             FAIL(runner, "Offset %" PRId64 " for %s not a multiple of 8",
-                 offset, Str_Get_Ptr8(file));
+                 offset, str);
+            free(str);
             break;
         }
     }

--- a/core/Lucy/Test/Store/TestFSFileHandle.c
+++ b/core/Lucy/Test/Store/TestFSFileHandle.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h> // for remove()
+#include <stdlib.h>
 
 #define C_LUCY_FSFILEHANDLE
 #define C_LUCY_FILEWINDOW
@@ -33,6 +34,13 @@
 #include "Lucy/Store/FSFileHandle.h"
 #include "Lucy/Store/FileWindow.h"
 
+static void
+S_remove(String *path) {
+    char *str = Str_To_Utf8(path);
+    remove(str);
+    free(str);
+}
+
 TestFSFileHandle*
 TestFSFH_new() {
     return (TestFSFileHandle*)Class_Make_Obj(TESTFSFILEHANDLE);
@@ -44,7 +52,7 @@ test_open(TestBatchRunner *runner) {
     FSFileHandle *fh;
     String *test_filename = SSTR_WRAP_C("_fstest");
 
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
 
     Err_set_error(NULL);
     fh = FSFH_open(test_filename, FH_READ_ONLY);
@@ -98,7 +106,7 @@ test_open(TestBatchRunner *runner) {
               "open() read only -- no errors");
     DECREF(fh);
 
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
 }
 
 static void
@@ -110,7 +118,7 @@ test_Read_Write(TestBatchRunner *runner) {
     char *buf = buffer;
     String *test_filename = SSTR_WRAP_C("_fstest");
 
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
     fh = FSFH_open(test_filename,
                    FH_CREATE | FH_WRITE_ONLY | FH_EXCLUSIVE);
 
@@ -157,7 +165,7 @@ test_Read_Write(TestBatchRunner *runner) {
               "Writing to a read-only handle sets error");
 
     DECREF(fh);
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
 }
 
 static void
@@ -165,7 +173,7 @@ test_Close(TestBatchRunner *runner) {
     String *test_filename = SSTR_WRAP_C("_fstest");
     FSFileHandle *fh;
 
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
     fh = FSFH_open(test_filename,
                    FH_CREATE | FH_WRITE_ONLY | FH_EXCLUSIVE);
     TEST_TRUE(runner, FSFH_Close(fh), "Close returns true for write-only");
@@ -173,7 +181,7 @@ test_Close(TestBatchRunner *runner) {
 
     // Simulate an OS error when closing the file descriptor.  This
     // approximates what would happen if, say, we run out of disk space.
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
     fh = FSFH_open(test_filename,
                    FH_CREATE | FH_WRITE_ONLY | FH_EXCLUSIVE);
 #ifdef _MSC_VER
@@ -194,7 +202,7 @@ test_Close(TestBatchRunner *runner) {
     TEST_TRUE(runner, FSFH_Close(fh), "Close returns true for read-only");
 
     DECREF(fh);
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
 }
 
 static void
@@ -205,7 +213,7 @@ test_Window(TestBatchRunner *runner) {
     FileWindowIVARS *const window_ivars = FileWindow_IVARS(window);
     uint32_t i;
 
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
     fh = FSFH_open(test_filename,
                    FH_CREATE | FH_WRITE_ONLY | FH_EXCLUSIVE);
     for (i = 0; i < 1024; i++) {
@@ -244,7 +252,7 @@ test_Window(TestBatchRunner *runner) {
 
     DECREF(window);
     DECREF(fh);
-    remove(Str_Get_Ptr8(test_filename));
+    S_remove(test_filename);
 }
 
 void


### PR DESCRIPTION
Use `Str_To_Utf8` which is guaranteed to return a nul-terminated C
string instead of `Str_To_Ptr8`.