### PR TITLE
LUCY-295 Adapt for changed return type of Vec_Get_Size

### DIFF
--- a/core/Lucy/Analysis/PolyAnalyzer.c
+++ b/core/Lucy/Analysis/PolyAnalyzer.c
@@ -87,7 +87,7 @@ PolyAnalyzer_Transform_IMP(PolyAnalyzer *self, Inversion *inversion) {
 Inversion*
 PolyAnalyzer_Transform_Text_IMP(PolyAnalyzer *self, String *text) {
     Vector *const   analyzers     = PolyAnalyzer_IVARS(self)->analyzers;
-    const uint32_t  num_analyzers = Vec_Get_Size(analyzers);
+    const size_t    num_analyzers = Vec_Get_Size(analyzers);
     Inversion      *retval;
 
     if (num_analyzers == 0) {
@@ -100,7 +100,7 @@ PolyAnalyzer_Transform_Text_IMP(PolyAnalyzer *self, String *text) {
     else {
         Analyzer *first_analyzer = (Analyzer*)Vec_Fetch(analyzers, 0);
         retval = Analyzer_Transform_Text(first_analyzer, text);
-        for (uint32_t i = 1; i < num_analyzers; i++) {
+        for (size_t i = 1; i < num_analyzers; i++) {
             Analyzer *analyzer = (Analyzer*)Vec_Fetch(analyzers, i);
             Inversion *new_inversion = Analyzer_Transform(analyzer, retval);
             DECREF(retval);

--- a/core/Lucy/Analysis/PolyAnalyzer.c
+++ b/core/Lucy/Analysis/PolyAnalyzer.c
@@ -38,7 +38,7 @@ PolyAnalyzer_init(PolyAnalyzer *self, String *language,
     PolyAnalyzerIVARS *const ivars = PolyAnalyzer_IVARS(self);
 
     if (analyzers) {
-        for (uint32_t i = 0, max = Vec_Get_Size(analyzers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(analyzers); i < max; i++) {
             CERTIFY(Vec_Fetch(analyzers, i), ANALYZER);
         }
         ivars->analyzers = (Vector*)INCREF(analyzers);
@@ -74,7 +74,7 @@ PolyAnalyzer_Transform_IMP(PolyAnalyzer *self, Inversion *inversion) {
     (void)INCREF(inversion);
 
     // Iterate through each of the analyzers in order.
-    for (uint32_t i = 0, max = Vec_Get_Size(analyzers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(analyzers); i < max; i++) {
         Analyzer *analyzer = (Analyzer*)Vec_Fetch(analyzers, i);
         Inversion *new_inversion = Analyzer_Transform(analyzer, inversion);
         DECREF(inversion);

--- a/core/Lucy/Highlight/HeatMap.c
+++ b/core/Lucy/Highlight/HeatMap.c
@@ -65,19 +65,19 @@ S_compare_i32(const void *va, const void *vb) {
 // offsets and lengths... but leave the scores at 0.
 static Vector*
 S_flattened_but_empty_spans(Vector *spans) {
-    const uint32_t num_spans = Vec_Get_Size(spans);
+    const size_t num_spans = Vec_Get_Size(spans);
     int32_t *bounds = (int32_t*)MALLOCATE((num_spans * 2) * sizeof(int32_t));
 
     // Assemble a list of all unique start/end boundaries.
-    for (uint32_t i = 0; i < num_spans; i++) {
+    for (size_t i = 0; i < num_spans; i++) {
         Span *span            = (Span*)Vec_Fetch(spans, i);
         bounds[i]             = Span_Get_Offset(span);
         bounds[i + num_spans] = Span_Get_Offset(span) + Span_Get_Length(span);
     }
     qsort(bounds, num_spans * 2, sizeof(uint32_t), S_compare_i32);
-    uint32_t num_bounds = 0;
+    size_t   num_bounds = 0;
     int32_t  last       = INT32_MAX;
-    for (uint32_t i = 0; i < num_spans * 2; i++) {
+    for (size_t i = 0; i < num_spans * 2; i++) {
         if (bounds[i] != last) {
             bounds[num_bounds++] = bounds[i];
             last = bounds[i];
@@ -86,7 +86,7 @@ S_flattened_but_empty_spans(Vector *spans) {
 
     // Create one Span for each zone between two bounds.
     Vector *flattened = Vec_new(num_bounds - 1);
-    for (uint32_t i = 0; i < num_bounds - 1; i++) {
+    for (size_t i = 0; i < num_bounds - 1; i++) {
         int32_t  start   = bounds[i];
         int32_t  length  = bounds[i + 1] - start;
         Vec_Push(flattened, (Obj*)Span_new(start, length, 0.0f));
@@ -98,7 +98,7 @@ S_flattened_but_empty_spans(Vector *spans) {
 
 Vector*
 HeatMap_Flatten_Spans_IMP(HeatMap *self, Vector *spans) {
-    const uint32_t num_spans = Vec_Get_Size(spans);
+    const size_t num_spans = Vec_Get_Size(spans);
     UNUSED_VAR(self);
 
     if (!num_spans) {
@@ -106,12 +106,12 @@ HeatMap_Flatten_Spans_IMP(HeatMap *self, Vector *spans) {
     }
     else {
         Vector *flattened = S_flattened_but_empty_spans(spans);
-        const uint32_t num_raw_flattened = Vec_Get_Size(flattened);
+        const size_t num_raw_flattened = Vec_Get_Size(flattened);
 
         // Iterate over each of the source spans, contributing their scores to
         // any destination span that falls within range.
-        uint32_t dest_tick = 0;
-        for (uint32_t i = 0; i < num_spans; i++) {
+        size_t dest_tick = 0;
+        for (size_t i = 0; i < num_spans; i++) {
             Span *source_span = (Span*)Vec_Fetch(spans, i);
             int32_t source_span_offset = Span_Get_Offset(source_span);
             int32_t source_span_len    = Span_Get_Length(source_span);
@@ -127,7 +127,7 @@ HeatMap_Flatten_Spans_IMP(HeatMap *self, Vector *spans) {
             }
 
             // Fill in scores.
-            for (uint32_t j = dest_tick; j < num_raw_flattened; j++) {
+            for (size_t j = dest_tick; j < num_raw_flattened; j++) {
                 Span *dest_span = (Span*)Vec_Fetch(flattened, j);
                 if (Span_Get_Offset(dest_span) == source_span_end) {
                     break;
@@ -142,7 +142,7 @@ HeatMap_Flatten_Spans_IMP(HeatMap *self, Vector *spans) {
 
         // Leave holes instead of spans that don't have any score.
         dest_tick = 0;
-        for (uint32_t i = 0; i < num_raw_flattened; i++) {
+        for (size_t i = 0; i < num_raw_flattened; i++) {
             Span *span = (Span*)Vec_Fetch(flattened, i);
             if (Span_Get_Weight(span)) {
                 Vec_Store(flattened, dest_tick++, INCREF(span));
@@ -180,13 +180,13 @@ HeatMap_Calc_Proximity_Boost_IMP(HeatMap *self, Span *span1, Span *span2) {
 Vector*
 HeatMap_Generate_Proximity_Boosts_IMP(HeatMap *self, Vector *spans) {
     Vector *boosts = Vec_new(0);
-    const uint32_t num_spans = Vec_Get_Size(spans);
+    const size_t num_spans = Vec_Get_Size(spans);
 
     if (num_spans > 1) {
-        for (uint32_t i = 0, max = num_spans - 1; i < max; i++) {
+        for (size_t i = 0, max = num_spans - 1; i < max; i++) {
             Span *span1 = (Span*)Vec_Fetch(spans, i);
 
-            for (uint32_t j = i + 1; j <= max; j++) {
+            for (size_t j = i + 1; j <= max; j++) {
                 Span *span2 = (Span*)Vec_Fetch(spans, j);
                 float prox_score
                     = HeatMap_Calc_Proximity_Boost(self, span1, span2);

--- a/core/Lucy/Highlight/HeatMap.c
+++ b/core/Lucy/Highlight/HeatMap.c
@@ -74,7 +74,7 @@ S_flattened_but_empty_spans(Vector *spans) {
         bounds[i]             = Span_Get_Offset(span);
         bounds[i + num_spans] = Span_Get_Offset(span) + Span_Get_Length(span);
     }
-    qsort(bounds, num_spans * 2, sizeof(uint32_t), S_compare_i32);
+    qsort(bounds, num_spans * 2, sizeof(int32_t), S_compare_i32);
     size_t   num_bounds = 0;
     int32_t  last       = INT32_MAX;
     for (size_t i = 0; i < num_spans * 2; i++) {

--- a/core/Lucy/Highlight/Highlighter.c
+++ b/core/Lucy/Highlight/Highlighter.c
@@ -200,7 +200,7 @@ S_hottest(HeatMap *heat_map) {
     float max_score = 0.0f;
     int32_t retval = 0;
     Vector *spans = HeatMap_Get_Spans(heat_map);
-    for (uint32_t i = Vec_Get_Size(spans); i--;) {
+    for (size_t i = Vec_Get_Size(spans); i--;) {
         Span *span = (Span*)Vec_Fetch(spans, i);
         if (Span_Get_Weight(span) >= max_score) {
             retval = Span_Get_Offset(span);
@@ -477,7 +477,7 @@ Highlighter_Highlight_Excerpt_IMP(Highlighter *self, Vector *spans,
     CharBuf        *encode_buf      = NULL;
     int32_t         raw_excerpt_end = top + Str_Length(raw_excerpt);
 
-    for (uint32_t i = 0, max = Vec_Get_Size(spans); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(spans); i < max; i++) {
         Span *span = (Span*)Vec_Fetch(spans, i);
         int32_t offset = Span_Get_Offset(span);
         if (offset < top) {

--- a/core/Lucy/Index/BackgroundMerger.c
+++ b/core/Lucy/Index/BackgroundMerger.c
@@ -203,12 +203,12 @@ BGMerger_Optimize_IMP(BackgroundMerger *self) {
     BGMerger_IVARS(self)->optimize = true;
 }
 
-static uint32_t
+static size_t
 S_maybe_merge(BackgroundMerger *self) {
     BackgroundMergerIVARS *const ivars = BGMerger_IVARS(self);
     Vector *to_merge = IxManager_Recycle(ivars->manager, ivars->polyreader,
                                          ivars->del_writer, 0, ivars->optimize);
-    int32_t num_to_merge = Vec_Get_Size(to_merge);
+    size_t num_to_merge = Vec_Get_Size(to_merge);
 
     // There's no point in merging one segment if it has no deletions, because
     // we'd just be rewriting it. */
@@ -228,7 +228,7 @@ S_maybe_merge(BackgroundMerger *self) {
     SegWriter_Prep_Seg_Dir(ivars->seg_writer);
 
     // Consolidate segments.
-    for (uint32_t i = 0, max = num_to_merge; i < max; i++) {
+    for (size_t i = 0, max = num_to_merge; i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(to_merge, i);
         String    *seg_name   = SegReader_Get_Seg_Name(seg_reader);
         int64_t    doc_count  = Seg_Get_Count(ivars->segment);
@@ -319,12 +319,12 @@ S_merge_updated_deletions(BackgroundMerger *self) {
 
         SegWriter_Prep_Seg_Dir(seg_writer);
 
-        for (uint32_t i = 0, max = Vec_Get_Size(merge_seg_readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(merge_seg_readers); i < max; i++) {
             SegReader *seg_reader
                 = (SegReader*)Vec_Fetch(merge_seg_readers, i);
             if (SegReader_Get_Seg_Num(seg_reader) == merge_seg_num) {
                 I32Array *offsets = PolyReader_Offsets(merge_polyreader);
-                seg_tick = i;
+                seg_tick = (uint32_t)i;
                 offset = I32Arr_Get(offsets, seg_tick);
                 DECREF(offsets);
             }
@@ -372,8 +372,8 @@ void
 BGMerger_Prepare_Commit_IMP(BackgroundMerger *self) {
     BackgroundMergerIVARS *const ivars = BGMerger_IVARS(self);
     Vector   *seg_readers     = PolyReader_Get_Seg_Readers(ivars->polyreader);
-    uint32_t  num_seg_readers = Vec_Get_Size(seg_readers);
-    uint32_t  segs_merged     = 0;
+    size_t    num_seg_readers = Vec_Get_Size(seg_readers);
+    size_t    segs_merged     = 0;
 
     if (ivars->prepared) {
         THROW(ERR, "Can't call Prepare_Commit() more than once");

--- a/core/Lucy/Index/BackgroundMerger.c
+++ b/core/Lucy/Index/BackgroundMerger.c
@@ -127,7 +127,7 @@ BGMerger_init(BackgroundMerger *self, Obj *index, IndexManager *manager) {
         = IxManager_Highest_Seg_Num(ivars->manager, ivars->snapshot) + 1;
     Vector *fields = Schema_All_Fields(ivars->schema);
     ivars->segment = Seg_new(new_seg_num);
-    for (uint32_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
         Seg_Add_Field(ivars->segment, (String*)Vec_Fetch(fields, i));
     }
     DECREF(fields);
@@ -261,13 +261,13 @@ S_merge_updated_deletions(BackgroundMerger *self) {
         = PolyReader_Get_Seg_Readers(ivars->polyreader);
     Hash *new_segs = Hash_new(Vec_Get_Size(new_seg_readers));
 
-    for (uint32_t i = 0, max = Vec_Get_Size(new_seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(new_seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(new_seg_readers, i);
         String    *seg_name   = SegReader_Get_Seg_Name(seg_reader);
         Hash_Store(new_segs, seg_name, INCREF(seg_reader));
     }
 
-    for (uint32_t i = 0, max = Vec_Get_Size(old_seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(old_seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(old_seg_readers, i);
         String    *seg_name   = SegReader_Get_Seg_Name(seg_reader);
 
@@ -443,7 +443,7 @@ BGMerger_Prepare_Commit_IMP(BackgroundMerger *self) {
             // run this AFTER S_merge_updated_deletions, because otherwise
             // we couldn't tell whether the deletion counts changed.)
             Vector *files = Snapshot_List(latest_snapshot);
-            for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+            for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
                 String *file = (String*)Vec_Fetch(files, i);
                 if (Str_Starts_With_Utf8(file, "seg_", 4)) {
                     int64_t gen = (int64_t)IxFileNames_extract_gen(file);

--- a/core/Lucy/Index/DeletionsReader.c
+++ b/core/Lucy/Index/DeletionsReader.c
@@ -61,7 +61,7 @@ PolyDelReader_init(PolyDeletionsReader *self, Vector *readers,
     DelReader_init((DeletionsReader*)self, NULL, NULL, NULL, NULL, -1);
     PolyDeletionsReaderIVARS *const ivars = PolyDelReader_IVARS(self);
     ivars->del_count = 0;
-    for (uint32_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
         DeletionsReader *reader = (DeletionsReader*)CERTIFY(
                                       Vec_Fetch(readers, i), DELETIONSREADER);
         ivars->del_count += DelReader_Del_Count(reader);
@@ -75,7 +75,7 @@ void
 PolyDelReader_Close_IMP(PolyDeletionsReader *self) {
     PolyDeletionsReaderIVARS *const ivars = PolyDelReader_IVARS(self);
     if (ivars->readers) {
-        for (uint32_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
             DeletionsReader *reader
                 = (DeletionsReader*)Vec_Fetch(ivars->readers, i);
             if (reader) { DelReader_Close(reader); }

--- a/core/Lucy/Index/DeletionsReader.c
+++ b/core/Lucy/Index/DeletionsReader.c
@@ -166,8 +166,8 @@ DefDelReader_Read_Deletions_IMP(DefaultDeletionsReader *self) {
     // Start with deletions files in the most recently added segments and work
     // backwards.  The first one we find which addresses our segment is the
     // one we need.
-    for (int32_t i = Vec_Get_Size(segments) - 1; i >= 0; i--) {
-        Segment *other_seg = (Segment*)Vec_Fetch(segments, i);
+    for (int32_t i = (int32_t)Vec_Get_Size(segments) - 1; i >= 0; i--) {
+        Segment *other_seg = (Segment*)Vec_Fetch(segments, (size_t)i);
         Hash *metadata
             = (Hash*)Seg_Fetch_Metadata_Utf8(other_seg, "deletions", 9);
         if (metadata) {

--- a/core/Lucy/Index/DeletionsReader.c
+++ b/core/Lucy/Index/DeletionsReader.c
@@ -102,9 +102,9 @@ PolyDelReader_Iterator_IMP(PolyDeletionsReader *self) {
     PolyDeletionsReaderIVARS *const ivars = PolyDelReader_IVARS(self);
     SeriesMatcher *deletions = NULL;
     if (ivars->del_count) {
-        uint32_t num_readers = Vec_Get_Size(ivars->readers);
+        size_t num_readers = Vec_Get_Size(ivars->readers);
         Vector *matchers = Vec_new(num_readers);
-        for (uint32_t i = 0; i < num_readers; i++) {
+        for (size_t i = 0; i < num_readers; i++) {
             DeletionsReader *reader
                 = (DeletionsReader*)Vec_Fetch(ivars->readers, i);
             Matcher *matcher = DelReader_Iterator(reader);

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -85,7 +85,7 @@ DefDelWriter_init(DefaultDeletionsWriter *self, Schema *schema,
     DataWriter_init((DataWriter*)self, schema, snapshot, segment, polyreader);
     DefaultDeletionsWriterIVARS *const ivars = DefDelWriter_IVARS(self);
     ivars->seg_readers          = PolyReader_Seg_Readers(polyreader);
-    uint32_t num_seg_readers    = Vec_Get_Size(ivars->seg_readers);
+    size_t num_seg_readers      = Vec_Get_Size(ivars->seg_readers);
     ivars->seg_starts           = PolyReader_Offsets(polyreader);
     ivars->bit_vecs             = Vec_new(num_seg_readers);
     ivars->updated              = (bool*)CALLOCATE(num_seg_readers, sizeof(bool));
@@ -93,7 +93,7 @@ DefDelWriter_init(DefaultDeletionsWriter *self, Schema *schema,
     ivars->name_to_tick         = Hash_new(num_seg_readers);
 
     // Materialize a BitVector of deletions for each segment.
-    for (uint32_t i = 0; i < num_seg_readers; i++) {
+    for (size_t i = 0; i < num_seg_readers; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
         BitVector *bit_vec    = BitVec_new(SegReader_Doc_Max(seg_reader));
         DeletionsReader *del_reader

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -144,7 +144,7 @@ DefDelWriter_Finish_IMP(DefaultDeletionsWriter *self) {
     DefaultDeletionsWriterIVARS *const ivars = DefDelWriter_IVARS(self);
     Folder *const folder = ivars->folder;
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
         if (ivars->updated[i]) {
             BitVector *deldocs   = (BitVector*)Vec_Fetch(ivars->bit_vecs, i);
@@ -181,7 +181,7 @@ DefDelWriter_Metadata_IMP(DefaultDeletionsWriter *self) {
     Hash    *const metadata = super_meta(self);
     Hash    *const files    = Hash_new(0);
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
         if (ivars->updated[i]) {
             BitVector *deldocs   = (BitVector*)Vec_Fetch(ivars->bit_vecs, i);
@@ -250,7 +250,7 @@ void
 DefDelWriter_Delete_By_Term_IMP(DefaultDeletionsWriter *self,
                                 String *field, Obj *term) {
     DefaultDeletionsWriterIVARS *const ivars = DefDelWriter_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
         PostingListReader *plist_reader
             = (PostingListReader*)SegReader_Fetch(
@@ -280,7 +280,7 @@ DefDelWriter_Delete_By_Query_IMP(DefaultDeletionsWriter *self, Query *query) {
     Compiler *compiler = Query_Make_Compiler(query, (Searcher*)ivars->searcher,
                                              Query_Get_Boost(query), false);
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
         BitVector *bit_vec = (BitVector*)Vec_Fetch(ivars->bit_vecs, i);
         Matcher *matcher = Compiler_Make_Matcher(compiler, seg_reader, false);
@@ -320,7 +320,7 @@ DefDelWriter_Delete_By_Doc_ID_IMP(DefaultDeletionsWriter *self, int32_t doc_id) 
 bool
 DefDelWriter_Updated_IMP(DefaultDeletionsWriter *self) {
     DefaultDeletionsWriterIVARS *const ivars = DefDelWriter_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         if (ivars->updated[i]) { return true; }
     }
     return false;
@@ -358,7 +358,7 @@ DefDelWriter_Merge_Segment_IMP(DefaultDeletionsWriter *self,
                  * we're adding correspond to.  If it's gone, we don't
                  * need to worry about losing deletions files that point
                  * at it. */
-                for (uint32_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
+                for (size_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
                     SegReader *candidate
                         = (SegReader*)Vec_Fetch(seg_readers, i);
                     String *candidate_name

--- a/core/Lucy/Index/DocReader.c
+++ b/core/Lucy/Index/DocReader.c
@@ -54,7 +54,7 @@ PolyDocReader*
 PolyDocReader_init(PolyDocReader *self, Vector *readers, I32Array *offsets) {
     DocReader_init((DocReader*)self, NULL, NULL, NULL, NULL, -1);
     PolyDocReaderIVARS *const ivars = PolyDocReader_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
         CERTIFY(Vec_Fetch(readers, i), DOCREADER);
     }
     ivars->readers = (Vector*)INCREF(readers);
@@ -66,7 +66,7 @@ void
 PolyDocReader_Close_IMP(PolyDocReader *self) {
     PolyDocReaderIVARS *const ivars = PolyDocReader_IVARS(self);
     if (ivars->readers) {
-        for (uint32_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
             DocReader *reader = (DocReader*)Vec_Fetch(ivars->readers, i);
             if (reader) { DocReader_Close(reader); }
         }

--- a/core/Lucy/Index/FilePurger.c
+++ b/core/Lucy/Index/FilePurger.c
@@ -230,9 +230,9 @@ S_discover_unused(FilePurger *self, Vector **purgables_ptr,
             if (lock && Lock_Is_Locked(lock)) {
                 // The snapshot file is locked, which means someone's using
                 // that version of the index -- protect all of its entries.
-                uint32_t new_size = Vec_Get_Size(spared)
-                                    + Vec_Get_Size(referenced)
-                                    + 1;
+                size_t new_size = Vec_Get_Size(spared)
+                                  + Vec_Get_Size(referenced)
+                                  + 1;
                 Vec_Grow(spared, new_size);
                 Vec_Push(spared, (Obj*)Str_Clone(entry));
                 Vec_Push_All(spared, referenced);

--- a/core/Lucy/Index/FilePurger.c
+++ b/core/Lucy/Index/FilePurger.c
@@ -96,7 +96,7 @@ FilePurger_Purge_IMP(FilePurger *self) {
         // again later.  Proceed in reverse lexical order so that directories
         // get deleted after they've been emptied.
         Vec_Sort(purgables);
-        for (uint32_t i = Vec_Get_Size(purgables); i--;) {
+        for (size_t i = Vec_Get_Size(purgables); i--;) {
             String *entry = (String*)Vec_Fetch(purgables, i);
             if (Hash_Fetch(ivars->disallowed, entry)) { continue; }
             if (!Folder_Delete(folder, entry)) {
@@ -106,14 +106,14 @@ FilePurger_Purge_IMP(FilePurger *self) {
             }
         }
 
-        for (uint32_t i = 0, max = Vec_Get_Size(snapshots); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(snapshots); i < max; i++) {
             Snapshot *snapshot = (Snapshot*)Vec_Fetch(snapshots, i);
             bool snapshot_has_failures = false;
             if (Hash_Get_Size(failures)) {
                 // Only delete snapshot files if all of their entries were
                 // successfully deleted.
                 Vector *entries = Snapshot_List(snapshot);
-                for (uint32_t j = Vec_Get_Size(entries); j--;) {
+                for (size_t j = Vec_Get_Size(entries); j--;) {
                     String *entry = (String*)Vec_Fetch(entries, j);
                     if (Hash_Fetch(failures, entry)) {
                         snapshot_has_failures = true;
@@ -240,7 +240,7 @@ S_discover_unused(FilePurger *self, Vector **purgables_ptr,
             else {
                 // No one's using this snapshot, so all of its entries are
                 // candidates for deletion.
-                for (uint32_t i = 0, max = Vec_Get_Size(referenced); i < max; i++) {
+                for (size_t i = 0, max = Vec_Get_Size(referenced); i < max; i++) {
                     String *file = (String*)Vec_Fetch(referenced, i);
                     Hash_Store(candidates, file, (Obj*)CFISH_TRUE);
                 }
@@ -260,7 +260,7 @@ S_discover_unused(FilePurger *self, Vector **purgables_ptr,
     S_zap_dead_merge(self, candidates);
 
     // Eliminate any current files from the list of files to be purged.
-    for (uint32_t i = 0, max = Vec_Get_Size(spared); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(spared); i < max; i++) {
         String *filename = (String*)Vec_Fetch(spared, i);
         DECREF(Hash_Delete(candidates, filename));
     }
@@ -276,12 +276,12 @@ S_discover_unused(FilePurger *self, Vector **purgables_ptr,
 static Vector*
 S_find_all_referenced(Folder *folder, Vector *entries) {
     Hash *uniqued = Hash_new(Vec_Get_Size(entries));
-    for (uint32_t i = 0, max = Vec_Get_Size(entries); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(entries); i < max; i++) {
         String *entry = (String*)Vec_Fetch(entries, i);
         Hash_Store(uniqued, entry, (Obj*)CFISH_TRUE);
         if (Folder_Is_Directory(folder, entry)) {
             Vector *contents = Folder_List_R(folder, entry);
-            for (uint32_t j = Vec_Get_Size(contents); j--;) {
+            for (size_t j = Vec_Get_Size(contents); j--;) {
                 String *sub_entry = (String*)Vec_Fetch(contents, j);
                 Hash_Store(uniqued, sub_entry, (Obj*)CFISH_TRUE);
             }

--- a/core/Lucy/Index/HighlightReader.c
+++ b/core/Lucy/Index/HighlightReader.c
@@ -61,7 +61,7 @@ PolyHLReader_init(PolyHighlightReader *self, Vector *readers,
                   I32Array *offsets) {
     HLReader_init((HighlightReader*)self, NULL, NULL, NULL, NULL, -1);
     PolyHighlightReaderIVARS *const ivars = PolyHLReader_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
         CERTIFY(Vec_Fetch(readers, i), HIGHLIGHTREADER);
     }
     ivars->readers = (Vector*)INCREF(readers);
@@ -73,7 +73,7 @@ void
 PolyHLReader_Close_IMP(PolyHighlightReader *self) {
     PolyHighlightReaderIVARS *const ivars = PolyHLReader_IVARS(self);
     if (ivars->readers) {
-        for (uint32_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
             HighlightReader *sub_reader
                 = (HighlightReader*)Vec_Fetch(ivars->readers, i);
             if (sub_reader) { HLReader_Close(sub_reader); }

--- a/core/Lucy/Index/IndexManager.c
+++ b/core/Lucy/Index/IndexManager.c
@@ -72,7 +72,7 @@ IxManager_Highest_Seg_Num_IMP(IndexManager *self, Snapshot *snapshot) {
     Vector *files = Snapshot_List(snapshot);
     uint64_t highest_seg_num = 0;
     UNUSED_VAR(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
         String *file = (String*)Vec_Fetch(files, i);
         if (Seg_valid_seg_name(file)) {
             uint64_t seg_num = IxFileNames_extract_gen(file);

--- a/core/Lucy/Index/Indexer.c
+++ b/core/Lucy/Index/Indexer.c
@@ -196,7 +196,7 @@ Indexer_init(Indexer *self, Schema *schema, Obj *index,
 
     // Add all known fields to Segment.
     Vector *fields = Schema_All_Fields(schema);
-    for (uint32_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
         Seg_Add_Field(ivars->segment, (String*)Vec_Fetch(fields, i));
     }
     DECREF(fields);
@@ -344,14 +344,14 @@ Indexer_Add_Index_IMP(Indexer *self, Obj *index) {
         Schema_Eat(schema, other_schema);
 
         // Add fields to Segment.
-        for (uint32_t i = 0, max = Vec_Get_Size(other_fields); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(other_fields); i < max; i++) {
             String *other_field = (String*)Vec_Fetch(other_fields, i);
             Seg_Add_Field(ivars->segment, other_field);
         }
         DECREF(other_fields);
 
         // Add all segments.
-        for (uint32_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
             SegReader *seg_reader = (SegReader*)Vec_Fetch(seg_readers, i);
             DeletionsReader *del_reader
                 = (DeletionsReader*)SegReader_Fetch(
@@ -383,7 +383,7 @@ static String*
 S_find_schema_file(Snapshot *snapshot) {
     Vector *files = Snapshot_List(snapshot);
     String *retval = NULL;
-    for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
         String *file = (String*)Vec_Fetch(files, i);
         if (Str_Starts_With_Utf8(file, "schema_", 7)
             && Str_Ends_With_Utf8(file, ".json", 5)
@@ -434,7 +434,7 @@ S_maybe_merge(Indexer *self, Vector *seg_readers) {
                                          ivars->del_writer, cutoff, ivars->optimize);
 
     Hash *seen = Hash_new(Vec_Get_Size(to_merge));
-    for (uint32_t i = 0, max = Vec_Get_Size(to_merge); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(to_merge); i < max; i++) {
         SegReader *seg_reader
             = (SegReader*)CERTIFY(Vec_Fetch(to_merge, i), SEGREADER);
         String *seg_name = SegReader_Get_Seg_Name(seg_reader);
@@ -449,7 +449,7 @@ S_maybe_merge(Indexer *self, Vector *seg_readers) {
     DECREF(seen);
 
     // Consolidate segments if either sparse or optimizing forced.
-    for (uint32_t i = 0, max = Vec_Get_Size(to_merge); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(to_merge); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(to_merge, i);
         int64_t seg_num = SegReader_Get_Seg_Num(seg_reader);
         Matcher *deletions

--- a/core/Lucy/Index/Indexer.c
+++ b/core/Lucy/Index/Indexer.c
@@ -400,7 +400,7 @@ static bool
 S_maybe_merge(Indexer *self, Vector *seg_readers) {
     IndexerIVARS *const ivars = Indexer_IVARS(self);
     bool      merge_happened  = false;
-    uint32_t  num_seg_readers = Vec_Get_Size(seg_readers);
+    size_t    num_seg_readers = Vec_Get_Size(seg_readers);
     Lock     *merge_lock      = IxManager_Make_Merge_Lock(ivars->manager);
     bool      got_merge_lock  = Lock_Obtain(merge_lock);
     int64_t   cutoff;
@@ -484,7 +484,7 @@ void
 Indexer_Prepare_Commit_IMP(Indexer *self) {
     IndexerIVARS *const ivars = Indexer_IVARS(self);
     Vector   *seg_readers     = PolyReader_Get_Seg_Readers(ivars->polyreader);
-    uint32_t  num_seg_readers = Vec_Get_Size(seg_readers);
+    size_t    num_seg_readers = Vec_Get_Size(seg_readers);
     bool      merge_happened  = false;
 
     if (!ivars->write_lock || ivars->prepared) {

--- a/core/Lucy/Index/Inverter.c
+++ b/core/Lucy/Index/Inverter.c
@@ -182,7 +182,7 @@ Inverter_Add_Field_IMP(Inverter *self, InverterEntry *entry) {
 void
 Inverter_Clear_IMP(Inverter *self) {
     InverterIVARS *const ivars = Inverter_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->entries); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->entries); i < max; i++) {
         InvEntry_Clear((InverterEntry*)Vec_Fetch(ivars->entries, i));
     }
     Vec_Clear(ivars->entries);

--- a/core/Lucy/Index/Inverter.c
+++ b/core/Lucy/Index/Inverter.c
@@ -80,7 +80,7 @@ Inverter_Iterate_IMP(Inverter *self) {
         Vec_Sort(ivars->entries);
         ivars->sorted = true;
     }
-    return Vec_Get_Size(ivars->entries);
+    return (uint32_t)Vec_Get_Size(ivars->entries);
 }
 
 int32_t

--- a/core/Lucy/Index/LexiconReader.c
+++ b/core/Lucy/Index/LexiconReader.c
@@ -56,7 +56,7 @@ PolyLexiconReader*
 PolyLexReader_init(PolyLexiconReader *self, Vector *readers,
                    I32Array *offsets) {
     Schema *schema = NULL;
-    for (uint32_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(readers); i < max; i++) {
         LexiconReader *reader
             = (LexiconReader*)CERTIFY(Vec_Fetch(readers, i), LEXICONREADER);
         if (!schema) { schema = LexReader_Get_Schema(reader); }
@@ -72,7 +72,7 @@ void
 PolyLexReader_Close_IMP(PolyLexiconReader *self) {
     PolyLexiconReaderIVARS *const ivars = PolyLexReader_IVARS(self);
     if (ivars->readers) {
-        for (uint32_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
             LexiconReader *reader
                 = (LexiconReader*)Vec_Fetch(ivars->readers, i);
             if (reader) { LexReader_Close(reader); }
@@ -116,7 +116,7 @@ PolyLexReader_Doc_Freq_IMP(PolyLexiconReader *self, String *field,
                            Obj *term) {
     PolyLexiconReaderIVARS *const ivars = PolyLexReader_IVARS(self);
     uint32_t doc_freq = 0;
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->readers); i < max; i++) {
         LexiconReader *reader = (LexiconReader*)Vec_Fetch(ivars->readers, i);
         if (reader) {
             doc_freq += LexReader_Doc_Freq(reader, field, term);

--- a/core/Lucy/Index/PolyLexicon.c
+++ b/core/Lucy/Index/PolyLexicon.c
@@ -95,7 +95,6 @@ void
 PolyLex_Reset_IMP(PolyLexicon *self) {
     PolyLexiconIVARS *const ivars = PolyLex_IVARS(self);
     Vector *seg_lexicons = ivars->seg_lexicons;
-    uint32_t num_segs = Vec_Get_Size(seg_lexicons);
     SegLexQueue *lex_q = ivars->lex_q;
 
     // Empty out the queue.
@@ -106,7 +105,7 @@ PolyLex_Reset_IMP(PolyLexicon *self) {
     }
 
     // Fill the queue with valid SegLexicons.
-    for (uint32_t i = 0; i < num_segs; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(seg_lexicons); i < max; i++) {
         SegLexicon *const seg_lexicon
             = (SegLexicon*)Vec_Fetch(seg_lexicons, i);
         SegLex_Reset(seg_lexicon);

--- a/core/Lucy/Index/PolyLexicon.c
+++ b/core/Lucy/Index/PolyLexicon.c
@@ -81,7 +81,7 @@ S_refresh_lex_q(SegLexQueue *lex_q, Vector *seg_lexicons, Obj *target) {
     }
 
     // Refill the queue.
-    for (uint32_t i = 0, max = Vec_Get_Size(seg_lexicons); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(seg_lexicons); i < max; i++) {
         SegLexicon *const seg_lexicon
             = (SegLexicon*)Vec_Fetch(seg_lexicons, i);
         SegLex_Seek(seg_lexicon, target);

--- a/core/Lucy/Index/PolyLexicon.c
+++ b/core/Lucy/Index/PolyLexicon.c
@@ -36,17 +36,17 @@ PolyLex_new(String *field, Vector *sub_readers) {
 
 PolyLexicon*
 PolyLex_init(PolyLexicon *self, String *field, Vector *sub_readers) {
-    uint32_t  num_sub_readers = Vec_Get_Size(sub_readers);
+    size_t    num_sub_readers = Vec_Get_Size(sub_readers);
     Vector   *seg_lexicons    = Vec_new(num_sub_readers);
 
     // Init.
     Lex_init((Lexicon*)self, field);
     PolyLexiconIVARS *const ivars = PolyLex_IVARS(self);
     ivars->term            = NULL;
-    ivars->lex_q           = SegLexQ_new(num_sub_readers);
+    ivars->lex_q           = SegLexQ_new((uint32_t)num_sub_readers);
 
     // Derive.
-    for (uint32_t i = 0; i < num_sub_readers; i++) {
+    for (size_t i = 0; i < num_sub_readers; i++) {
         LexiconReader *lex_reader = (LexiconReader*)Vec_Fetch(sub_readers, i);
         if (lex_reader && CERTIFY(lex_reader, LEXICONREADER)) {
             Lexicon *seg_lexicon = LexReader_Lexicon(lex_reader, field, NULL);
@@ -192,7 +192,7 @@ PolyLex_Get_Term_IMP(PolyLexicon *self) {
 uint32_t
 PolyLex_Get_Num_Seg_Lexicons_IMP(PolyLexicon *self) {
     PolyLexiconIVARS *const ivars = PolyLex_IVARS(self);
-    return Vec_Get_Size(ivars->seg_lexicons);
+    return (uint32_t)Vec_Get_Size(ivars->seg_lexicons);
 }
 
 SegLexQueue*

--- a/core/Lucy/Index/PolyReader.c
+++ b/core/Lucy/Index/PolyReader.c
@@ -164,9 +164,9 @@ PolyReader_init(PolyReader *self, Schema *schema, Folder *folder,
     ivars->del_count  = 0;
 
     if (sub_readers) {
-        uint32_t num_segs = Vec_Get_Size(sub_readers);
+        size_t num_segs = Vec_Get_Size(sub_readers);
         Vector *segments = Vec_new(num_segs);
-        for (uint32_t i = 0; i < num_segs; i++) {
+        for (size_t i = 0; i < num_segs; i++) {
             SegReader *seg_reader
                 = (SegReader*)CERTIFY(Vec_Fetch(sub_readers, i), SEGREADER);
             Vec_Push(segments, INCREF(SegReader_Get_Segment(seg_reader)));

--- a/core/Lucy/Index/PolyReader.c
+++ b/core/Lucy/Index/PolyReader.c
@@ -93,7 +93,7 @@ PolyReader_open(Obj *index, Snapshot *snapshot, IndexManager *manager) {
 
 static Obj*
 S_first_non_null(Vector *array) {
-    for (uint32_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
         Obj *thing = Vec_Fetch(array, i);
         if (thing) { return thing; }
     }
@@ -191,7 +191,7 @@ PolyReader_Close_IMP(PolyReader *self) {
     PolyReaderIVARS *const ivars = PolyReader_IVARS(self);
     PolyReader_Close_t super_close
         = SUPER_METHOD_PTR(POLYREADER, LUCY_PolyReader_Close);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->sub_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->sub_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->sub_readers, i);
         SegReader_Close(seg_reader);
     }
@@ -234,7 +234,7 @@ S_try_open_elements(void *context) {
     String     *schema_file       = NULL;
 
     // Find schema file, count segments.
-    for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
         String *entry = (String*)Vec_Fetch(files, i);
 
         if (Seg_valid_seg_name(entry)) {
@@ -272,7 +272,7 @@ S_try_open_elements(void *context) {
     }
 
     Vector *segments = Vec_new(num_segs);
-    for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
         String *entry = (String*)Vec_Fetch(files, i);
 
         // Create a Segment for each segmeta.

--- a/core/Lucy/Index/PolyReader.c
+++ b/core/Lucy/Index/PolyReader.c
@@ -103,7 +103,7 @@ S_first_non_null(Vector *array) {
 static void
 S_init_sub_readers(PolyReader *self, Vector *sub_readers) {
     PolyReaderIVARS *const ivars = PolyReader_IVARS(self);
-    uint32_t  num_sub_readers = Vec_Get_Size(sub_readers);
+    size_t   num_sub_readers = Vec_Get_Size(sub_readers);
     int32_t *starts = (int32_t*)MALLOCATE(num_sub_readers * sizeof(int32_t));
     Hash  *data_readers = Hash_new(0);
 
@@ -113,7 +113,7 @@ S_init_sub_readers(PolyReader *self, Vector *sub_readers) {
 
     // Accumulate doc_max, subreader start offsets, and DataReaders.
     ivars->doc_max = 0;
-    for (uint32_t i = 0; i < num_sub_readers; i++) {
+    for (size_t i = 0; i < num_sub_readers; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(sub_readers, i);
         Hash *components = SegReader_Get_Components(seg_reader);
         starts[i] = ivars->doc_max;
@@ -131,7 +131,7 @@ S_init_sub_readers(PolyReader *self, Vector *sub_readers) {
         }
         DECREF(iter);
     }
-    ivars->offsets = I32Arr_new_steal(starts, num_sub_readers);
+    ivars->offsets = I32Arr_new_steal(starts, (uint32_t)num_sub_readers);
 
     HashIterator *iter = HashIter_new(data_readers);
     while (HashIter_Next(iter)) {

--- a/core/Lucy/Index/PostingListWriter.c
+++ b/core/Lucy/Index/PostingListWriter.c
@@ -167,7 +167,7 @@ PListWriter_Add_Inverted_Doc_IMP(PostingListWriter *self, Inverter *inverter,
     // flush all of them, then release all the RawPostings with a single
     // action.
     if (MemPool_Get_Consumed(ivars->mem_pool) > ivars->mem_thresh) {
-        for (uint32_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
             PostingPool *const pool = (PostingPool*)Vec_Fetch(ivars->pools, i);
             if (pool) { PostPool_Flush(pool); }
         }
@@ -185,7 +185,7 @@ PListWriter_Add_Segment_IMP(PostingListWriter *self, SegReader *reader,
     Vector  *all_fields    = Schema_All_Fields(schema);
     S_lazy_init(self);
 
-    for (uint32_t i = 0, max = Vec_Get_Size(all_fields); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(all_fields); i < max; i++) {
         String    *field = (String*)Vec_Fetch(all_fields, i);
         FieldType *type  = Schema_Fetch_Type(schema, field);
         int32_t old_field_num = Seg_Field_Num(other_segment, field);
@@ -223,13 +223,13 @@ PListWriter_Finish_IMP(PostingListWriter *self) {
     OutStream_Close(ivars->post_temp_out);
 
     // Try to free up some memory.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
         PostingPool *pool = (PostingPool*)Vec_Fetch(ivars->pools, i);
         if (pool) { PostPool_Shrink(pool); }
     }
 
     // Write postings for each field.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->pools); i < max; i++) {
         PostingPool *pool = (PostingPool*)Vec_Delete(ivars->pools, i);
         if (pool) {
             // Write out content for each PostingPool.  Let each PostingPool

--- a/core/Lucy/Index/PostingPool.c
+++ b/core/Lucy/Index/PostingPool.c
@@ -174,7 +174,7 @@ PostPool_Get_Mem_Pool_IMP(PostingPool *self) {
 void
 PostPool_Flip_IMP(PostingPool *self) {
     PostingPoolIVARS *const ivars = PostPool_IVARS(self);
-    uint32_t num_runs   = Vec_Get_Size(ivars->runs);
+    size_t   num_runs   = Vec_Get_Size(ivars->runs);
     uint32_t sub_thresh = num_runs > 0
                           ? ivars->mem_thresh / num_runs
                           : ivars->mem_thresh;
@@ -217,7 +217,7 @@ PostPool_Flip_IMP(PostingPool *self) {
     }
 
     // Assign.
-    for (uint32_t i = 0; i < num_runs; i++) {
+    for (size_t i = 0; i < num_runs; i++) {
         PostingPool *run = (PostingPool*)Vec_Fetch(ivars->runs, i);
         if (run != NULL) {
             PostPool_Set_Mem_Thresh(run, sub_thresh);

--- a/core/Lucy/Index/SegWriter.c
+++ b/core/Lucy/Index/SegWriter.c
@@ -115,7 +115,7 @@ void
 SegWriter_Add_Inverted_Doc_IMP(SegWriter *self, Inverter *inverter,
                                int32_t doc_id) {
     SegWriterIVARS *const ivars = SegWriter_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
         DataWriter *writer = (DataWriter*)Vec_Fetch(ivars->writers, i);
         DataWriter_Add_Inverted_Doc(writer, inverter, doc_id);
     }
@@ -140,7 +140,7 @@ SegWriter_Add_Segment_IMP(SegWriter *self, SegReader *reader,
     SegWriterIVARS *const ivars = SegWriter_IVARS(self);
 
     // Bulk add the slab of documents to the various writers.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
         DataWriter *writer = (DataWriter*)Vec_Fetch(ivars->writers, i);
         DataWriter_Add_Segment(writer, reader, doc_map);
     }
@@ -161,7 +161,7 @@ SegWriter_Merge_Segment_IMP(SegWriter *self, SegReader *reader,
     String   *seg_name = Seg_Get_Name(SegReader_Get_Segment(reader));
 
     // Have all the sub-writers merge the segment.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
         DataWriter *writer = (DataWriter*)Vec_Fetch(ivars->writers, i);
         DataWriter_Merge_Segment(writer, reader, doc_map);
     }
@@ -181,7 +181,7 @@ SegWriter_Delete_Segment_IMP(SegWriter *self, SegReader *reader) {
     String   *seg_name = Seg_Get_Name(SegReader_Get_Segment(reader));
 
     // Have all the sub-writers delete the segment.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
         DataWriter *writer = (DataWriter*)Vec_Fetch(ivars->writers, i);
         DataWriter_Delete_Segment(writer, reader);
     }
@@ -197,7 +197,7 @@ SegWriter_Finish_IMP(SegWriter *self) {
     String *seg_name = Seg_Get_Name(ivars->segment);
 
     // Finish off children.
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->writers); i < max; i++) {
         DataWriter *writer = (DataWriter*)Vec_Fetch(ivars->writers, i);
         DataWriter_Finish(writer);
     }

--- a/core/Lucy/Index/Segment.c
+++ b/core/Lucy/Index/Segment.c
@@ -166,7 +166,7 @@ Seg_Add_Field_IMP(Segment *self, String *field) {
         return (int32_t)Int_Get_Value(num);
     }
     else {
-        int32_t field_num = Vec_Get_Size(ivars->by_num);
+        int32_t field_num = (int32_t)Vec_Get_Size(ivars->by_num);
         Hash_Store(ivars->by_name, field, (Obj*)Int_new(field_num));
         Vec_Push(ivars->by_num, (Obj*)Str_Clone(field));
         return field_num;

--- a/core/Lucy/Index/Segment.c
+++ b/core/Lucy/Index/Segment.c
@@ -119,7 +119,7 @@ Seg_Read_File_IMP(Segment *self, Folder *folder) {
     // Get list of field nums.
     Vector *source_by_num = (Vector*)Hash_Fetch_Utf8(my_metadata,
                                                      "field_names", 11);
-    uint32_t num_fields = source_by_num ? Vec_Get_Size(source_by_num) : 0;
+    size_t num_fields = source_by_num ? Vec_Get_Size(source_by_num) : 0;
     if (source_by_num == NULL) {
         THROW(ERR, "Failed to extract 'field_names' from metadata");
     }
@@ -131,7 +131,7 @@ Seg_Read_File_IMP(Segment *self, Folder *folder) {
     ivars->by_name = Hash_new(num_fields);
 
     // Copy the list of fields from the source.
-    for (uint32_t i = 0; i < num_fields; i++) {
+    for (size_t i = 0; i < num_fields; i++) {
         String *name = (String*)Vec_Fetch(source_by_num, i);
         Seg_Add_Field(self, name);
     }

--- a/core/Lucy/Index/Snapshot.c
+++ b/core/Lucy/Index/Snapshot.c
@@ -141,7 +141,7 @@ Snapshot_Read_File_IMP(Snapshot *self, Folder *folder, String *path) {
             list = cleaned;
         }
         Hash_Clear(ivars->entries);
-        for (uint32_t i = 0, max = Vec_Get_Size(list); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(list); i < max; i++) {
             String *entry
                 = (String*)CERTIFY(Vec_Fetch(list, i), STRING);
             Hash_Store(ivars->entries, entry, (Obj*)CFISH_TRUE);
@@ -160,7 +160,7 @@ S_clean_segment_contents(Vector *orig) {
     // within segment directories being listed.  Filter these files because
     // they cause a problem with FilePurger.
     Vector *cleaned = Vec_new(Vec_Get_Size(orig));
-    for (uint32_t i = 0, max = Vec_Get_Size(orig); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(orig); i < max; i++) {
         String *name = (String*)Vec_Fetch(orig, i);
         if (!Seg_valid_seg_name(name)) {
             if (Str_Starts_With_Utf8(name, "seg_", 4)) {

--- a/core/Lucy/Index/SortFieldWriter.c
+++ b/core/Lucy/Index/SortFieldWriter.c
@@ -483,7 +483,7 @@ void
 SortFieldWriter_Flip_IMP(SortFieldWriter *self) {
     SortFieldWriterIVARS *const ivars = SortFieldWriter_IVARS(self);
     uint32_t num_items = SortFieldWriter_Buffer_Count(self);
-    uint32_t num_runs = Vec_Get_Size(ivars->runs);
+    size_t   num_runs = Vec_Get_Size(ivars->runs);
 
     if (ivars->flipped) { THROW(ERR, "Can't call Flip() twice"); }
     ivars->flipped = true;
@@ -491,7 +491,7 @@ SortFieldWriter_Flip_IMP(SortFieldWriter *self) {
     // Sanity check.
     if (num_runs && num_items) {
         THROW(ERR, "Sanity check failed: num_runs: %u32 num_items: %u32",
-              num_runs, num_items);
+              (uint32_t)num_runs, num_items);
     }
 
     if (num_items) {
@@ -518,7 +518,7 @@ SortFieldWriter_Flip_IMP(SortFieldWriter *self) {
         // Assign streams and a slice of mem_thresh.
         size_t sub_thresh = ivars->mem_thresh / num_runs;
         if (sub_thresh < 65536) { sub_thresh = 65536; }
-        for (uint32_t i = 0; i < num_runs; i++) {
+        for (size_t i = 0; i < num_runs; i++) {
             SortFieldWriter *run = (SortFieldWriter*)Vec_Fetch(ivars->runs, i);
             S_flip_run(run, sub_thresh, ivars->ord_in, ivars->ix_in,
                        ivars->dat_in);

--- a/core/Lucy/Index/SortWriter.c
+++ b/core/Lucy/Index/SortWriter.c
@@ -152,7 +152,7 @@ SortWriter_Add_Inverted_Doc_IMP(SortWriter *self, Inverter *inverter,
     // flush all of them, then reset the counter which tracks memory
     // consumption.
     if ((size_t)Counter_Get_Value(ivars->counter) > ivars->mem_thresh) {
-        for (uint32_t i = 0; i < Vec_Get_Size(ivars->field_writers); i++) {
+        for (size_t i = 0; i < Vec_Get_Size(ivars->field_writers); i++) {
             SortFieldWriter *const field_writer
                 = (SortFieldWriter*)Vec_Fetch(ivars->field_writers, i);
             if (field_writer) { SortFieldWriter_Flush(field_writer); }
@@ -169,7 +169,7 @@ SortWriter_Add_Segment_IMP(SortWriter *self, SegReader *reader,
     Vector *fields = Schema_All_Fields(ivars->schema);
 
     // Proceed field-at-a-time, rather than doc-at-a-time.
-    for (uint32_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
         String *field = (String*)Vec_Fetch(fields, i);
         SortReader *sort_reader = (SortReader*)SegReader_Fetch(
                                       reader, Class_Get_Name(SORTREADER));
@@ -199,7 +199,7 @@ SortWriter_Finish_IMP(SortWriter *self) {
     // If we've either flushed or added segments, flush everything so that any
     // one field can use the entire margin up to mem_thresh.
     if (ivars->flush_at_finish) {
-        for (uint32_t i = 1, max = Vec_Get_Size(field_writers); i < max; i++) {
+        for (size_t i = 1, max = Vec_Get_Size(field_writers); i < max; i++) {
             SortFieldWriter *field_writer
                 = (SortFieldWriter*)Vec_Fetch(field_writers, i);
             if (field_writer) {

--- a/core/Lucy/Index/SortWriter.c
+++ b/core/Lucy/Index/SortWriter.c
@@ -213,11 +213,11 @@ SortWriter_Finish_IMP(SortWriter *self) {
     OutStream_Close(ivars->temp_ix_out);
     OutStream_Close(ivars->temp_dat_out);
 
-    for (uint32_t i = 1, max = Vec_Get_Size(field_writers); i < max; i++) {
+    for (size_t i = 1, max = Vec_Get_Size(field_writers); i < max; i++) {
         SortFieldWriter *field_writer
             = (SortFieldWriter*)Vec_Delete(field_writers, i);
         if (field_writer) {
-            String *field = Seg_Field_Name(ivars->segment, i);
+            String *field = Seg_Field_Name(ivars->segment, (int32_t)i);
             SortFieldWriter_Flip(field_writer);
             int32_t count = SortFieldWriter_Finish(field_writer);
             Hash_Store(ivars->counts, field, (Obj*)Str_newf("%i32", count));

--- a/core/Lucy/Plan/Schema.c
+++ b/core/Lucy/Plan/Schema.c
@@ -85,7 +85,7 @@ Schema_Destroy_IMP(Schema *self) {
 static void
 S_add_unique(Vector *array, Obj *elem) {
     if (!elem) { return; }
-    for (uint32_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
         Obj *candidate = Vec_Fetch(array, i);
         if (!candidate) { continue; }
         if (elem == candidate) { return; }

--- a/core/Lucy/Plan/Schema.c
+++ b/core/Lucy/Plan/Schema.c
@@ -229,9 +229,9 @@ Schema_All_Fields_IMP(Schema *self) {
     return Hash_Keys(Schema_IVARS(self)->types);
 }
 
-uint32_t
+size_t
 S_find_in_array(Vector *array, Obj *obj) {
-    for (uint32_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
         Obj *candidate = Vec_Fetch(array, i);
         if (obj == NULL && candidate == NULL) {
             return i;
@@ -245,7 +245,7 @@ S_find_in_array(Vector *array, Obj *obj) {
         }
     }
     THROW(ERR, "Couldn't find match for %o", obj);
-    UNREACHABLE_RETURN(uint32_t);
+    UNREACHABLE_RETURN(size_t);
 }
 
 Hash*
@@ -273,12 +273,12 @@ Schema_Dump_IMP(Schema *self) {
             FullTextType *fttype = (FullTextType*)type;
             Hash *type_dump = FullTextType_Dump_For_Schema(fttype);
             Analyzer *analyzer = FullTextType_Get_Analyzer(fttype);
-            uint32_t tick
+            size_t tick
                 = S_find_in_array(ivars->uniq_analyzers, (Obj*)analyzer);
 
             // Store the tick which references a unique analyzer.
             Hash_Store_Utf8(type_dump, "analyzer", 8,
-                            (Obj*)Str_newf("%u32", tick));
+                            (Obj*)Str_newf("%u64", (uint64_t)tick));
 
             Hash_Store(type_dumps, field, (Obj*)type_dump);
         }

--- a/core/Lucy/Search/ANDQuery.c
+++ b/core/Lucy/Search/ANDQuery.c
@@ -46,12 +46,12 @@ ANDQuery_init(ANDQuery *self, Vector *children) {
 String*
 ANDQuery_To_String_IMP(ANDQuery *self) {
     ANDQueryIVARS *const ivars = ANDQuery_IVARS(self);
-    uint32_t num_kids = Vec_Get_Size(ivars->children);
+    size_t num_kids = Vec_Get_Size(ivars->children);
     if (!num_kids) { return Str_new_from_trusted_utf8("()", 2); }
     else {
         CharBuf *buf = CB_new(0);
         CB_Cat_Trusted_Utf8(buf, "(", 1);
-        for (uint32_t i = 0; i < num_kids; i++) {
+        for (size_t i = 0; i < num_kids; i++) {
             String *kid_string = Obj_To_String(Vec_Fetch(ivars->children, i));
             CB_Cat(buf, kid_string);
             DECREF(kid_string);
@@ -108,7 +108,7 @@ Matcher*
 ANDCompiler_Make_Matcher_IMP(ANDCompiler *self, SegReader *reader,
                              bool need_score) {
     ANDCompilerIVARS *const ivars = ANDCompiler_IVARS(self);
-    uint32_t num_kids = Vec_Get_Size(ivars->children);
+    size_t num_kids = Vec_Get_Size(ivars->children);
 
     if (num_kids == 1) {
         Compiler *only_child = (Compiler*)Vec_Fetch(ivars->children, 0);
@@ -118,7 +118,7 @@ ANDCompiler_Make_Matcher_IMP(ANDCompiler *self, SegReader *reader,
         Vector *child_matchers = Vec_new(num_kids);
 
         // Add child matchers one by one.
-        for (uint32_t i = 0; i < num_kids; i++) {
+        for (size_t i = 0; i < num_kids; i++) {
             Compiler *child = (Compiler*)Vec_Fetch(ivars->children, i);
             Matcher *child_matcher
                 = Compiler_Make_Matcher(child, reader, need_score);

--- a/core/Lucy/Search/Collector/SortCollector.c
+++ b/core/Lucy/Search/Collector/SortCollector.c
@@ -89,7 +89,7 @@ SortColl_init(SortCollector *self, Schema *schema, SortSpec *sort_spec,
     Vector *rules = sort_spec
                     ? (Vector*)INCREF(SortSpec_Get_Rules(sort_spec))
                     : S_default_sort_rules();
-    uint32_t num_rules = Vec_Get_Size(rules);
+    uint32_t num_rules = (uint32_t)Vec_Get_Size(rules);
 
     // Validate.
     if (sort_spec && !schema) {

--- a/core/Lucy/Search/HitQueue.c
+++ b/core/Lucy/Search/HitQueue.c
@@ -48,7 +48,7 @@ HitQ_init(HitQueue *self, Schema *schema, SortSpec *sort_spec,
     HitQueueIVARS *const ivars = HitQ_IVARS(self);
     if (sort_spec) {
         Vector   *rules      = SortSpec_Get_Rules(sort_spec);
-        uint32_t  num_rules  = Vec_Get_Size(rules);
+        uint32_t  num_rules  = (uint32_t)Vec_Get_Size(rules);
         uint32_t  action_num = 0;
 
         if (!schema) {

--- a/core/Lucy/Search/IndexSearcher.c
+++ b/core/Lucy/Search/IndexSearcher.c
@@ -139,7 +139,7 @@ IxSearcher_Collect_IMP(IndexSearcher *self, Query *query, Collector *collector) 
                                                Query_Get_Boost(query), false);
 
     // Accumulate hits into the Collector.
-    for (uint32_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(seg_readers, i);
         DeletionsReader *del_reader = (DeletionsReader*)SegReader_Fetch(
                                           seg_reader,
@@ -147,7 +147,7 @@ IxSearcher_Collect_IMP(IndexSearcher *self, Query *query, Collector *collector) 
         Matcher *matcher
             = Compiler_Make_Matcher(compiler, seg_reader, need_score);
         if (matcher) {
-            int32_t  seg_start = I32Arr_Get(seg_starts, i);
+            int32_t  seg_start = I32Arr_Get(seg_starts, (uint32_t)i);
             Matcher *deletions = DelReader_Iterator(del_reader);
             Coll_Set_Reader(collector, seg_reader);
             Coll_Set_Base(collector, seg_start);

--- a/core/Lucy/Search/ORQuery.c
+++ b/core/Lucy/Search/ORQuery.c
@@ -61,13 +61,13 @@ ORQuery_Equals_IMP(ORQuery *self, Obj *other) {
 String*
 ORQuery_To_String_IMP(ORQuery *self) {
     ORQueryIVARS *const ivars = ORQuery_IVARS(self);
-    uint32_t num_kids = Vec_Get_Size(ivars->children);
+    size_t num_kids = Vec_Get_Size(ivars->children);
     if (!num_kids) { return Str_new_from_trusted_utf8("()", 2); }
     else {
         CharBuf *buf = CB_new(0);
         CB_Cat_Trusted_Utf8(buf, "(", 1);
-        uint32_t last_kid = num_kids - 1;
-        for (uint32_t i = 0; i < num_kids; i++) {
+        size_t last_kid = num_kids - 1;
+        for (size_t i = 0; i < num_kids; i++) {
             String *kid_string = Obj_To_String(Vec_Fetch(ivars->children, i));
             CB_Cat(buf, kid_string);
             DECREF(kid_string);
@@ -104,7 +104,7 @@ Matcher*
 ORCompiler_Make_Matcher_IMP(ORCompiler *self, SegReader *reader,
                             bool need_score) {
     ORCompilerIVARS *const ivars = ORCompiler_IVARS(self);
-    uint32_t num_kids = Vec_Get_Size(ivars->children);
+    size_t num_kids = Vec_Get_Size(ivars->children);
 
     if (num_kids == 1) {
         // No need for an ORMatcher wrapper.
@@ -116,7 +116,7 @@ ORCompiler_Make_Matcher_IMP(ORCompiler *self, SegReader *reader,
         uint32_t num_submatchers = 0;
 
         // Accumulate sub-matchers.
-        for (uint32_t i = 0; i < num_kids; i++) {
+        for (size_t i = 0; i < num_kids; i++) {
             Compiler *child = (Compiler*)Vec_Fetch(ivars->children, i);
             Matcher *submatcher
                 = Compiler_Make_Matcher(child, reader, need_score);

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -350,7 +350,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
         = PhraseQuery_IVARS((PhraseQuery*)ivars->parent);
     Vector *const      terms     = parent_ivars->terms;
     Vector *const      spans     = Vec_new(0);
-    const uint32_t     num_terms = Vec_Get_Size(terms);
+    const uint32_t     num_terms = (uint32_t)Vec_Get_Size(terms);
     UNUSED_VAR(searcher);
 
     // Bail if no terms or field doesn't match.
@@ -395,7 +395,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
     }
 
     // Proceed only if all terms are present.
-    uint32_t num_tvs = Vec_Get_Size(term_vectors);
+    uint32_t num_tvs = (uint32_t)Vec_Get_Size(term_vectors);
     if (num_tvs == num_terms) {
         TermVector *first_tv = (TermVector*)Vec_Fetch(term_vectors, 0);
         TermVector *last_tv

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -68,7 +68,7 @@ static PhraseQuery*
 S_do_init(PhraseQuery *self, String *field, Vector *terms, float boost) {
     Query_init((Query*)self, boost);
     PhraseQueryIVARS *const ivars = PhraseQuery_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         CERTIFY(Vec_Fetch(terms, i), OBJ);
     }
     ivars->field = field;
@@ -218,7 +218,7 @@ PhraseCompiler_init(PhraseCompiler *self, PhraseQuery *parent,
 
     // Store IDF for the phrase.
     ivars->idf = 0;
-    for (uint32_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         Obj     *term     = Vec_Fetch(terms, i);
         int32_t  doc_max  = Searcher_Doc_Max(searcher);
         int32_t  doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field, term);

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -138,11 +138,11 @@ PhraseQuery_Equals_IMP(PhraseQuery *self, Obj *other) {
 String*
 PhraseQuery_To_String_IMP(PhraseQuery *self) {
     PhraseQueryIVARS *const ivars = PhraseQuery_IVARS(self);
-    uint32_t  num_terms = Vec_Get_Size(ivars->terms);
+    size_t  num_terms = Vec_Get_Size(ivars->terms);
     CharBuf  *buf       = CB_new(0);
     CB_Cat(buf, ivars->field);
     CB_Cat_Trusted_Utf8(buf, ":\"", 2);
-    for (uint32_t i = 0; i < num_terms; i++) {
+    for (size_t i = 0; i < num_terms; i++) {
         Obj    *term        = Vec_Fetch(ivars->terms, i);
         String *term_string = Obj_To_String(term);
         CB_Cat(buf, term_string);
@@ -300,7 +300,7 @@ PhraseCompiler_Make_Matcher_IMP(PhraseCompiler *self, SegReader *reader,
     PhraseQueryIVARS *const parent_ivars
         = PhraseQuery_IVARS((PhraseQuery*)ivars->parent);
     Vector *const      terms     = parent_ivars->terms;
-    uint32_t           num_terms = Vec_Get_Size(terms);
+    size_t             num_terms = Vec_Get_Size(terms);
 
     // Bail if there are no terms.
     if (!num_terms) { return NULL; }
@@ -322,7 +322,7 @@ PhraseCompiler_Make_Matcher_IMP(PhraseCompiler *self, SegReader *reader,
 
     // Look up each term.
     Vector  *plists = Vec_new(num_terms);
-    for (uint32_t i = 0; i < num_terms; i++) {
+    for (size_t i = 0; i < num_terms; i++) {
         Obj *term = Vec_Fetch(terms, i);
         PostingList *plist
             = PListReader_Posting_List(plist_reader, parent_ivars->field, term);

--- a/core/Lucy/Search/PolyQuery.c
+++ b/core/Lucy/Search/PolyQuery.c
@@ -164,7 +164,7 @@ PolyCompiler_Sum_Of_Squared_Weights_IMP(PolyCompiler *self) {
     float sum      = 0;
     float my_boost = PolyCompiler_Get_Boost(self);
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
         Compiler *child = (Compiler*)Vec_Fetch(ivars->children, i);
         sum += Compiler_Sum_Of_Squared_Weights(child);
     }
@@ -178,7 +178,7 @@ PolyCompiler_Sum_Of_Squared_Weights_IMP(PolyCompiler *self) {
 void
 PolyCompiler_Apply_Norm_Factor_IMP(PolyCompiler *self, float factor) {
     PolyCompilerIVARS *const ivars = PolyCompiler_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
         Compiler *child = (Compiler*)Vec_Fetch(ivars->children, i);
         Compiler_Apply_Norm_Factor(child, factor);
     }
@@ -189,7 +189,7 @@ PolyCompiler_Highlight_Spans_IMP(PolyCompiler *self, Searcher *searcher,
                                  DocVector *doc_vec, String *field) {
     PolyCompilerIVARS *const ivars = PolyCompiler_IVARS(self);
     Vector *spans = Vec_new(0);
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->children); i < max; i++) {
         Compiler *child = (Compiler*)Vec_Fetch(ivars->children, i);
         Vector *child_spans = Compiler_Highlight_Spans(child, searcher,
                                                        doc_vec, field);

--- a/core/Lucy/Search/PolyQuery.c
+++ b/core/Lucy/Search/PolyQuery.c
@@ -70,7 +70,7 @@ PolyQuery_Get_Children_IMP(PolyQuery *self) {
 void
 PolyQuery_Serialize_IMP(PolyQuery *self, OutStream *outstream) {
     PolyQueryIVARS *const ivars = PolyQuery_IVARS(self);
-    const uint32_t num_kids = Vec_Get_Size(ivars->children);
+    const uint32_t num_kids = (uint32_t)Vec_Get_Size(ivars->children);
     OutStream_Write_F32(outstream, ivars->boost);
     OutStream_Write_U32(outstream, num_kids);
     for (uint32_t i = 0; i < num_kids; i++) {

--- a/core/Lucy/Search/PolyQuery.c
+++ b/core/Lucy/Search/PolyQuery.c
@@ -30,11 +30,11 @@
 
 PolyQuery*
 PolyQuery_init(PolyQuery *self, Vector *children) {
-    const uint32_t num_kids = children ? Vec_Get_Size(children) : 0;
+    const size_t num_kids = children ? Vec_Get_Size(children) : 0;
     Query_init((Query*)self, 1.0f);
     PolyQueryIVARS *const ivars = PolyQuery_IVARS(self);
     ivars->children = Vec_new(num_kids);
-    for (uint32_t i = 0; i < num_kids; i++) {
+    for (size_t i = 0; i < num_kids; i++) {
         PolyQuery_Add_Child(self, (Query*)Vec_Fetch(children, i));
     }
     return self;
@@ -134,13 +134,13 @@ PolyCompiler_init(PolyCompiler *self, PolyQuery *parent,
                   Searcher *searcher, float boost) {
     PolyCompilerIVARS *const ivars = PolyCompiler_IVARS(self);
     PolyQueryIVARS *const parent_ivars = PolyQuery_IVARS(parent);
-    const uint32_t num_kids = Vec_Get_Size(parent_ivars->children);
+    const size_t num_kids = Vec_Get_Size(parent_ivars->children);
 
     Compiler_init((Compiler*)self, (Query*)parent, searcher, NULL, boost);
     ivars->children = Vec_new(num_kids);
 
     // Iterate over the children, creating a Compiler for each one.
-    for (uint32_t i = 0; i < num_kids; i++) {
+    for (size_t i = 0; i < num_kids; i++) {
         Query *child_query = (Query*)Vec_Fetch(parent_ivars->children, i);
         float sub_boost = boost * Query_Get_Boost(child_query);
         Compiler *child_compiler

--- a/core/Lucy/Search/PolySearcher.c
+++ b/core/Lucy/Search/PolySearcher.c
@@ -41,7 +41,7 @@ PolySearcher_new(Schema *schema, Vector *searchers) {
 
 PolySearcher*
 PolySearcher_init(PolySearcher *self, Schema *schema, Vector *searchers) {
-    const uint32_t num_searchers = Vec_Get_Size(searchers);
+    const uint32_t num_searchers = (uint32_t)Vec_Get_Size(searchers);
     int32_t *starts_array = (int32_t*)MALLOCATE(num_searchers * sizeof(int32_t));
     int32_t  doc_max      = 0;
 
@@ -182,8 +182,8 @@ PolySearcher_Collect_IMP(PolySearcher *self, Query *query,
     Vector *const searchers = ivars->searchers;
     I32Array *starts = ivars->starts;
 
-    for (uint32_t i = 0, max = Vec_Get_Size(searchers); i < max; i++) {
-        int32_t start = I32Arr_Get(starts, i);
+    for (size_t i = 0, max = Vec_Get_Size(searchers); i < max; i++) {
+        int32_t start = I32Arr_Get(starts, (uint32_t)i);
         Searcher *searcher = (Searcher*)Vec_Fetch(searchers, i);
         OffsetCollector *offset_coll = OffsetColl_new(collector, start);
         Searcher_Collect(searcher, query, (Collector*)offset_coll);

--- a/core/Lucy/Search/QueryParser.c
+++ b/core/Lucy/Search/QueryParser.c
@@ -120,7 +120,7 @@ QParser_init(QueryParser *self, Schema *schema, Analyzer *analyzer,
 
     if (fields) {
         ivars->fields = Vec_Clone(fields);
-        for (uint32_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
             CERTIFY(Vec_Fetch(fields, i), STRING);
         }
         Vec_Sort(ivars->fields);
@@ -361,7 +361,7 @@ S_compose_inner_queries(QueryParser *self, Vector *elems,
     const int32_t default_occur = QParser_IVARS(self)->default_occur;
 
     // Generate all queries.  Apply any fields.
-    for (uint32_t i = Vec_Get_Size(elems); i--;) {
+    for (size_t i = Vec_Get_Size(elems); i--;) {
         String *field = default_field;
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i);
 
@@ -391,10 +391,10 @@ S_compose_inner_queries(QueryParser *self, Vector *elems,
 static void
 S_apply_plusses_and_negations(QueryParser *self, Vector *elems) {
     UNUSED_VAR(self);
-    for (uint32_t i = Vec_Get_Size(elems); i--;) {
+    for (size_t i = Vec_Get_Size(elems); i--;) {
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i);
         if (ParserElem_Get_Type(elem) == TOKEN_QUERY) {
-            for (uint32_t j = i; j--;) {
+            for (size_t j = i; j--;) {
                 ParserElem *prev = (ParserElem*)Vec_Fetch(elems, j);
                 uint32_t prev_type = ParserElem_Get_Type(prev);
                 if (prev_type == TOKEN_MINUS || prev_type == TOKEN_NOT) {
@@ -413,7 +413,7 @@ S_apply_plusses_and_negations(QueryParser *self, Vector *elems) {
 
 static void
 S_compose_not_queries(QueryParser *self, Vector *elems) {
-    for (uint32_t i = 0, max = Vec_Get_Size(elems); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(elems); i < max; i++) {
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i);
         if (ParserElem_Get_Type(elem) == TOKEN_QUERY
             && ParserElem_Negated(elem)
@@ -429,7 +429,7 @@ S_compose_not_queries(QueryParser *self, Vector *elems) {
 static void
 S_winnow_boolops(QueryParser *self, Vector *elems) {
     UNUSED_VAR(self);
-    for (uint32_t i = 0; i < Vec_Get_Size(elems); i++) {
+    for (size_t i = 0; i < Vec_Get_Size(elems); i++) {
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i);
         if (ParserElem_Get_Type(elem) != TOKEN_QUERY) {
             uint32_t num_to_zap = 0;
@@ -441,7 +441,7 @@ S_winnow_boolops(QueryParser *self, Vector *elems) {
             if (!following || ParserElem_Get_Type(following) != TOKEN_QUERY) {
                 num_to_zap = 1;
             }
-            for (uint32_t j = i + 1, jmax = Vec_Get_Size(elems); j < jmax; j++) {
+            for (size_t j = i + 1, jmax = Vec_Get_Size(elems); j < jmax; j++) {
                 ParserElem *maybe = (ParserElem*)Vec_Fetch(elems, j);
                 if (ParserElem_Get_Type(maybe) == TOKEN_QUERY) { break; }
                 else { num_to_zap++; }
@@ -456,7 +456,7 @@ static void
 S_compose_and_queries(QueryParser *self, Vector *elems) {
     const int32_t default_occur = QParser_IVARS(self)->default_occur;
 
-    for (uint32_t i = 0; i + 2 < Vec_Get_Size(elems); i++) {
+    for (size_t i = 0; i + 2 < Vec_Get_Size(elems); i++) {
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i + 1);
         if (ParserElem_Get_Type(elem) == TOKEN_AND) {
             ParserElem   *preceding  = (ParserElem*)Vec_Fetch(elems, i);
@@ -468,7 +468,7 @@ S_compose_and_queries(QueryParser *self, Vector *elems) {
             Vec_Push(children, INCREF(preceding_query));
 
             // Add following clauses.
-            for (uint32_t j = i + 1, jmax = Vec_Get_Size(elems);
+            for (size_t j = i + 1, jmax = Vec_Get_Size(elems);
                  j < jmax;
                  j += 2, num_to_zap += 2
                 ) {
@@ -503,7 +503,7 @@ static void
 S_compose_or_queries(QueryParser *self, Vector *elems) {
     const int32_t default_occur = QParser_IVARS(self)->default_occur;
 
-    for (uint32_t i = 0; i + 2 < Vec_Get_Size(elems); i++) {
+    for (size_t i = 0; i + 2 < Vec_Get_Size(elems); i++) {
         ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i + 1);
         if (ParserElem_Get_Type(elem) == TOKEN_OR) {
             ParserElem   *preceding  = (ParserElem*)Vec_Fetch(elems, i);
@@ -515,7 +515,7 @@ S_compose_or_queries(QueryParser *self, Vector *elems) {
             Vec_Push(children, INCREF(preceding_query));
 
             // Add following clauses.
-            for (uint32_t j = i + 1, jmax = Vec_Get_Size(elems);
+            for (size_t j = i + 1, jmax = Vec_Get_Size(elems);
                  j < jmax;
                  j += 2, num_to_zap += 2
                 ) {
@@ -668,7 +668,7 @@ S_has_valid_clauses(Query *query) {
     else if (Query_is_a(query, ORQUERY) || Query_is_a(query, ANDQUERY)) {
         PolyQuery *polyquery = (PolyQuery*)query;
         Vector    *children  = PolyQuery_Get_Children(polyquery);
-        for (uint32_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
             Query *child = (Query*)Vec_Fetch(children, i);
             if (S_has_valid_clauses(child)) {
                 return true;
@@ -698,7 +698,7 @@ S_do_prune(QueryParser *self, Query *query) {
         Vector    *children  = PolyQuery_Get_Children(polyquery);
 
         // Recurse.
-        for (uint32_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
             Query *child = (Query*)Vec_Fetch(children, i);
             S_do_prune(self, child);
         }
@@ -708,7 +708,7 @@ S_do_prune(QueryParser *self, Query *query) {
            ) {
             // Don't allow 'foo OR (-bar)'.
             Vector *children = PolyQuery_Get_Children(polyquery);
-            for (uint32_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
+            for (size_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
                 Query *child = (Query*)Vec_Fetch(children, i);
                 if (!S_has_valid_clauses(child)) {
                     Vec_Store(children, i, (Obj*)NoMatchQuery_new());
@@ -751,7 +751,7 @@ QParser_Expand_IMP(QueryParser *self, Query *query) {
         Vector *children = PolyQuery_Get_Children(polyquery);
         Vector *new_kids = Vec_new(Vec_Get_Size(children));
 
-        for (uint32_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(children); i < max; i++) {
             Query *child = (Query*)Vec_Fetch(children, i);
             Query *new_child = QParser_Expand(self, child); // recurse
             if (new_child) {
@@ -899,7 +899,7 @@ QParser_Expand_Leaf_IMP(QueryParser *self, Query *query) {
 
     CharBuf *unescape_buf = CB_new(Str_Get_Size(source_text));
     Vector  *queries      = Vec_new(Vec_Get_Size(fields));
-    for (uint32_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(fields); i < max; i++) {
         String   *field    = (String*)Vec_Fetch(fields, i);
         Analyzer *analyzer = ivars->analyzer
                              ? ivars->analyzer

--- a/core/Lucy/Search/QueryParser.c
+++ b/core/Lucy/Search/QueryParser.c
@@ -127,9 +127,9 @@ QParser_init(QueryParser *self, Schema *schema, Analyzer *analyzer,
     }
     else {
         Vector *all_fields = Schema_All_Fields(schema);
-        uint32_t num_fields = Vec_Get_Size(all_fields);
+        size_t num_fields = Vec_Get_Size(all_fields);
         ivars->fields = Vec_new(num_fields);
-        for (uint32_t i = 0; i < num_fields; i++) {
+        for (size_t i = 0; i < num_fields; i++) {
             String *field = (String*)Vec_Fetch(all_fields, i);
             FieldType *type = Schema_Fetch_Type(schema, field);
             if (type && FType_Indexed(type)) {
@@ -569,7 +569,7 @@ S_compose_subquery(QueryParser *self, Vector *elems, bool enclosed) {
         retval = (Query*)INCREF(query);
     }
     else {
-        uint32_t  num_elems = Vec_Get_Size(elems);
+        size_t    num_elems = Vec_Get_Size(elems);
         Vector   *required  = Vec_new(num_elems);
         Vector   *optional  = Vec_new(num_elems);
         Vector   *negated   = Vec_new(num_elems);
@@ -577,7 +577,7 @@ S_compose_subquery(QueryParser *self, Vector *elems, bool enclosed) {
         Query    *opt_query = NULL;
 
         // Demux elems into bins.
-        for (uint32_t i = 0; i < num_elems; i++) {
+        for (size_t i = 0; i < num_elems; i++) {
             ParserElem *elem = (ParserElem*)Vec_Fetch(elems, i);
             if (ParserElem_Required(elem)) {
                 Vec_Push(required, INCREF(ParserElem_As(elem, QUERY)));
@@ -589,9 +589,9 @@ S_compose_subquery(QueryParser *self, Vector *elems, bool enclosed) {
                 Vec_Push(negated, INCREF(ParserElem_As(elem, QUERY)));
             }
         }
-        uint32_t num_required = Vec_Get_Size(required);
-        uint32_t num_negated  = Vec_Get_Size(negated);
-        uint32_t num_optional = Vec_Get_Size(optional);
+        size_t num_required = Vec_Get_Size(required);
+        size_t num_negated  = Vec_Get_Size(negated);
+        size_t num_optional = Vec_Get_Size(optional);
 
         // Bind all mandatory matchers together in one Query.
         if (num_required || num_negated) {
@@ -914,11 +914,11 @@ QParser_Expand_Leaf_IMP(QueryParser *self, Query *query) {
             // Extract token texts.
             String *split_source = S_unescape(self, source_text, unescape_buf);
             Vector *maybe_texts = Analyzer_Split(analyzer, split_source);
-            uint32_t num_maybe_texts = Vec_Get_Size(maybe_texts);
+            size_t num_maybe_texts = Vec_Get_Size(maybe_texts);
             Vector *token_texts = Vec_new(num_maybe_texts);
 
             // Filter out zero-length token texts.
-            for (uint32_t j = 0; j < num_maybe_texts; j++) {
+            for (size_t j = 0; j < num_maybe_texts; j++) {
                 String *token_text = (String*)Vec_Fetch(maybe_texts, j);
                 if (Str_Get_Size(token_text)) {
                     Vec_Push(token_texts, INCREF(token_text));

--- a/core/Lucy/Search/SortSpec.c
+++ b/core/Lucy/Search/SortSpec.c
@@ -75,7 +75,7 @@ SortSpec_Get_Rules_IMP(SortSpec *self) {
 void
 SortSpec_Serialize_IMP(SortSpec *self, OutStream *target) {
     SortSpecIVARS *const ivars = SortSpec_IVARS(self);
-    uint32_t num_rules = Vec_Get_Size(ivars->rules);
+    uint32_t num_rules = (uint32_t)Vec_Get_Size(ivars->rules);
     OutStream_Write_C32(target, num_rules);
     for (uint32_t i = 0; i < num_rules; i++) {
         SortRule *rule = (SortRule*)Vec_Fetch(ivars->rules, i);

--- a/core/Lucy/Search/SortSpec.c
+++ b/core/Lucy/Search/SortSpec.c
@@ -37,7 +37,7 @@ SortSpec*
 SortSpec_init(SortSpec *self, Vector *rules) {
     SortSpecIVARS *const ivars = SortSpec_IVARS(self);
     ivars->rules = Vec_Clone(rules);
-    for (int32_t i = 0, max = Vec_Get_Size(rules); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(rules); i < max; i++) {
         SortRule *rule = (SortRule*)Vec_Fetch(rules, i);
         CERTIFY(rule, SORTRULE);
     }

--- a/core/Lucy/Store/CompoundFileWriter.c
+++ b/core/Lucy/Store/CompoundFileWriter.c
@@ -110,7 +110,7 @@ S_do_consolidate(CompoundFileWriter *self, CompoundFileWriterIVARS *ivars) {
                     (Obj*)Str_newf("%i32", CFWriter_current_file_format));
 
     Vec_Sort(files);
-    for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
         String *infilename = (String*)Vec_Fetch(files, i);
 
         if (!Str_Ends_With_Utf8(infilename, ".json", 5)) {
@@ -167,7 +167,7 @@ S_do_consolidate(CompoundFileWriter *self, CompoundFileWriterIVARS *ivars) {
     DECREF(iter);
     */
     DECREF(sub_files);
-    for (uint32_t i = 0, max = Vec_Get_Size(merged); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(merged); i < max; i++) {
         String *merged_file = (String*)Vec_Fetch(merged, i);
         if (!Folder_Delete(folder, merged_file)) {
             String *mess = MAKE_MESS("Can't delete '%o'", merged_file);

--- a/core/Lucy/Store/Folder.c
+++ b/core/Lucy/Store/Folder.c
@@ -181,14 +181,14 @@ Folder_Delete_Tree_IMP(Folder *self, String *path) {
                     }
                     DECREF(entry);
                 }
-                for (uint32_t i = 0, max = Vec_Get_Size(dirs); i < max; i++) {
+                for (size_t i = 0, max = Vec_Get_Size(dirs); i < max; i++) {
                     String *name = (String*)Vec_Fetch(files, i);
                     bool success = Folder_Delete_Tree(inner_folder, name);
                     if (!success && Folder_Local_Exists(inner_folder, name)) {
                         break;
                     }
                 }
-                for (uint32_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
+                for (size_t i = 0, max = Vec_Get_Size(files); i < max; i++) {
                     String *name = (String*)Vec_Fetch(files, i);
                     bool success = Folder_Local_Delete(inner_folder, name);
                     if (!success && Folder_Local_Exists(inner_folder, name)) {

--- a/core/Lucy/Test/Analysis/TestNormalizer.c
+++ b/core/Lucy/Test/Analysis/TestNormalizer.c
@@ -85,7 +85,7 @@ test_normalization(TestBatchRunner *runner) {
     Vector *tests = (Vector*)Json_slurp_json((Folder*)modules_folder, path);
     if (!tests) { RETHROW(Err_get_error()); }
 
-    for (uint32_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
         Hash *test = (Hash*)Vec_Fetch(tests, i);
         String *form = (String*)Hash_Fetch_Utf8(
                             test, "normalization_form", 18);
@@ -96,7 +96,7 @@ test_normalization(TestBatchRunner *runner) {
         Normalizer *normalizer = Normalizer_new(form, case_fold, strip_accents);
         Vector *words = (Vector*)Hash_Fetch_Utf8(test, "words", 5);
         Vector *norms = (Vector*)Hash_Fetch_Utf8(test, "norms", 5);
-        for (uint32_t j = 0, max = Vec_Get_Size(words); j < max; j++) {
+        for (size_t j = 0, max = Vec_Get_Size(words); j < max; j++) {
             String *word = (String*)Vec_Fetch(words, j);
             Vector *got  = Normalizer_Split(normalizer, word);
             String *norm = (String*)Vec_Fetch(got, 0);

--- a/core/Lucy/Test/Analysis/TestSnowballStemmer.c
+++ b/core/Lucy/Test/Analysis/TestSnowballStemmer.c
@@ -81,7 +81,7 @@ test_stemming(TestBatchRunner *runner) {
         Vector *words = (Vector*)Hash_Fetch_Utf8(lang_data, "words", 5);
         Vector *stems = (Vector*)Hash_Fetch_Utf8(lang_data, "stems", 5);
         SnowballStemmer *stemmer = SnowStemmer_new(iso);
-        for (uint32_t i = 0, max = Vec_Get_Size(words); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(words); i < max; i++) {
             String *word  = (String*)Vec_Fetch(words, i);
             char   *wstr  = Str_To_Utf8(word);
             Vector *got   = SnowStemmer_Split(stemmer, word);

--- a/core/Lucy/Test/Analysis/TestStandardTokenizer.c
+++ b/core/Lucy/Test/Analysis/TestStandardTokenizer.c
@@ -112,12 +112,13 @@ test_tokenizer(TestBatchRunner *runner) {
         Vector *tests = (Vector*)Json_slurp_json((Folder*)modules_folder, path);
         if (!tests) { RETHROW(Err_get_error()); }
 
-        for (uint32_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(tests); i < max; i++) {
             Hash *test = (Hash*)Vec_Fetch(tests, i);
             String *text = (String*)Hash_Fetch_Utf8(test, "text", 4);
             Vector *wanted = (Vector*)Hash_Fetch_Utf8(test, "words", 5);
             Vector *got = StandardTokenizer_Split(tokenizer, text);
-            TEST_TRUE(runner, Vec_Equals(wanted, (Obj*)got), "UCD test #%d", i + 1);
+            TEST_TRUE(runner, Vec_Equals(wanted, (Obj*)got), "UCD test #%d",
+                      (int)i + 1);
             DECREF(got);
         }
 

--- a/core/Lucy/Test/Index/TestSortWriter.c
+++ b/core/Lucy/Test/Index/TestSortWriter.c
@@ -251,7 +251,7 @@ test_sort_writer(TestBatchRunner *runner) {
     {
         Vector *filenames = RAMFolder_List_R(folder, NULL);
         int num_old_seg_files = 0;
-        for (uint32_t i = 0, size = Vec_Get_Size(filenames); i < size; ++i) {
+        for (size_t i = 0, size = Vec_Get_Size(filenames); i < size; ++i) {
             String *filename = (String*)Vec_Fetch(filenames, i);
             if (Str_Contains_Utf8(filename, "seg_1", 5)
                 || Str_Contains_Utf8(filename, "seg_2", 5)

--- a/core/Lucy/Test/Search/TestQueryParserSyntax.c
+++ b/core/Lucy/Test/Search/TestQueryParserSyntax.c
@@ -93,7 +93,7 @@ build_index() {
 
     // Index documents.
     Vector *doc_set = TestUtils_doc_set();
-    for (uint32_t i = 0; i < Vec_Get_Size(doc_set); ++i) {
+    for (size_t i = 0; i < Vec_Get_Size(doc_set); ++i) {
         String *content_string = (String*)Vec_Fetch(doc_set, i);
         Doc *doc = Doc_new(NULL, 0);
         Doc_Store(doc, plain_str, (Obj*)content_string);

--- a/core/Lucy/Test/Store/TestFSFolder.c
+++ b/core/Lucy/Test/Store/TestFSFolder.c
@@ -127,7 +127,7 @@ test_protect_symlinks(TestBatchRunner *runner) {
     else {
         Vector *list = FSFolder_List_R(folder, NULL);
         bool saw_bazooka_boffo = false;
-        for (uint32_t i = 0, max = Vec_Get_Size(list); i < max; i++) {
+        for (size_t i = 0, max = Vec_Get_Size(list); i < max; i++) {
             String *entry = (String*)Vec_Fetch(list, i);
             if (Str_Ends_With_Utf8(entry, "bazooka/boffo", 13)) {
                 saw_bazooka_boffo = true;

--- a/core/Lucy/Util/BlobSortEx.c
+++ b/core/Lucy/Util/BlobSortEx.c
@@ -147,7 +147,7 @@ BlobSortEx_Flip_IMP(BlobSortEx *self) {
     BlobSortEx_Flush(self);
 
     // Recalculate the approximate mem allowed for each run.
-    uint32_t num_runs = Vec_Get_Size(ivars->runs);
+    uint32_t num_runs = (uint32_t)Vec_Get_Size(ivars->runs);
     if (num_runs) {
         run_mem_thresh = (ivars->mem_thresh / 2) / num_runs;
         if (run_mem_thresh < 65536) {
@@ -195,7 +195,7 @@ BlobSortEx_Peek_Last_IMP(BlobSortEx *self) {
 uint32_t
 BlobSortEx_Get_Num_Runs_IMP(BlobSortEx *self) {
     BlobSortExIVARS *const ivars = BlobSortEx_IVARS(self);
-    return Vec_Get_Size(ivars->runs);
+    return (uint32_t)Vec_Get_Size(ivars->runs);
 }
 
 

--- a/core/Lucy/Util/Freezer.c
+++ b/core/Lucy/Util/Freezer.c
@@ -307,7 +307,7 @@ Freezer_read_hash(InStream *instream) {
 static Obj*
 S_dump_array(Vector *array) {
     Vector *dump = Vec_new(Vec_Get_Size(array));
-    for (uint32_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(array); i < max; i++) {
         Obj *elem = Vec_Fetch(array, i);
         if (elem) {
             Vec_Store(dump, i, Freezer_dump(elem));
@@ -451,7 +451,7 @@ Obj*
 S_load_from_array(Vector *dump) {
     Vector *loaded = Vec_new(Vec_Get_Size(dump));
 
-    for (uint32_t i = 0, max = Vec_Get_Size(dump); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(dump); i < max; i++) {
         Obj *elem_dump = Vec_Fetch(dump, i);
         if (elem_dump) {
             Vec_Store(loaded, i, Freezer_load(elem_dump));

--- a/core/Lucy/Util/Freezer.c
+++ b/core/Lucy/Util/Freezer.c
@@ -229,7 +229,7 @@ Freezer_read_blob(InStream *instream) {
 void
 Freezer_serialize_varray(Vector *array, OutStream *outstream) {
     uint32_t last_valid_tick = 0;
-    size_t size = Vec_Get_Size(array);
+    uint32_t size = (uint32_t)Vec_Get_Size(array);
     OutStream_Write_C32(outstream, size);
     for (uint32_t i = 0; i < size; i++) {
         Obj *elem = Vec_Fetch(array, i);

--- a/core/Lucy/Util/SortExternal.c
+++ b/core/Lucy/Util/SortExternal.c
@@ -197,7 +197,7 @@ SortEx_Shrink_IMP(SortExternal *self) {
     FREEMEM(ivars->scratch);
     ivars->scratch = NULL;
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->runs); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->runs); i < max; i++) {
         SortExternal *run = (SortExternal*)Vec_Fetch(ivars->runs, i);
         SortEx_Shrink(run);
     }
@@ -231,7 +231,7 @@ static Obj**
 S_find_endpost(SortExternal *self, SortExternalIVARS *ivars) {
     Obj **endpost = NULL;
 
-    for (uint32_t i = 0, max = Vec_Get_Size(ivars->runs); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(ivars->runs); i < max; i++) {
         // Get a run and retrieve the last item in its buffer.
         SortExternal *const run = (SortExternal*)Vec_Fetch(ivars->runs, i);
         SortExternalIVARS *const run_ivars = SortEx_IVARS(run);

--- a/core/Lucy/Util/SortExternal.c
+++ b/core/Lucy/Util/SortExternal.c
@@ -163,7 +163,7 @@ void
 SortEx_Add_Run_IMP(SortExternal *self, SortExternal *run) {
     SortExternalIVARS *const ivars = SortEx_IVARS(self);
     Vec_Push(ivars->runs, (Obj*)run);
-    uint32_t num_runs = Vec_Get_Size(ivars->runs);
+    size_t num_runs = Vec_Get_Size(ivars->runs);
     ivars->slice_sizes
         = (uint32_t*)REALLOCATE(ivars->slice_sizes,
                                 num_runs * sizeof(uint32_t));
@@ -262,7 +262,7 @@ S_find_endpost(SortExternal *self, SortExternalIVARS *ivars) {
 static void
 S_absorb_slices(SortExternal *self, SortExternalIVARS *ivars,
                 Obj **endpost) {
-    uint32_t    num_runs     = Vec_Get_Size(ivars->runs);
+    size_t      num_runs     = Vec_Get_Size(ivars->runs);
     Obj      ***slice_starts = ivars->slice_starts;
     uint32_t   *slice_sizes  = ivars->slice_sizes;
     Class      *klass        = SortEx_get_class(self);
@@ -273,7 +273,7 @@ S_absorb_slices(SortExternal *self, SortExternalIVARS *ivars,
     // Find non-empty slices.
     uint32_t num_slices = 0;
     uint32_t total_size = 0;
-    for (uint32_t i = 0; i < num_runs; i++) {
+    for (size_t i = 0; i < num_runs; i++) {
         SortExternal *const run = (SortExternal*)Vec_Fetch(ivars->runs, i);
         SortExternalIVARS *const run_ivars = SortEx_IVARS(run);
         uint32_t slice_size = S_find_slice_size(run, run_ivars, endpost);

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -72,7 +72,7 @@ S_do_init(ProximityQuery *self, String *field, Vector *terms, float boost,
           uint32_t within) {
     Query_init((Query*)self, boost);
     ProximityQueryIVARS *const ivars = ProximityQuery_IVARS(self);
-    for (uint32_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         CERTIFY(Vec_Fetch(terms, i), OBJ);
     }
     ivars->field  = field;
@@ -239,7 +239,7 @@ ProximityCompiler_init(ProximityCompiler *self, ProximityQuery *parent,
 
     // Store IDF for the phrase.
     ivars->idf = 0;
-    for (uint32_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
+    for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         Obj *term = Vec_Fetch(terms, i);
         int32_t doc_max  = Searcher_Doc_Max(searcher);
         int32_t doc_freq

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -379,7 +379,7 @@ ProximityCompiler_Highlight_Spans_IMP(ProximityCompiler *self,
         = ProximityQuery_IVARS((ProximityQuery*)ivars->parent);
     Vector         *const terms  = parent_ivars->terms;
     Vector         *const spans  = Vec_new(0);
-    const uint32_t  num_terms    = Vec_Get_Size(terms);
+    const uint32_t  num_terms    = (uint32_t)Vec_Get_Size(terms);
     UNUSED_VAR(searcher);
 
     // Bail if no terms or field doesn't match.
@@ -424,7 +424,7 @@ ProximityCompiler_Highlight_Spans_IMP(ProximityCompiler *self,
     }
 
     // Proceed only if all terms are present.
-    uint32_t num_tvs = Vec_Get_Size(term_vectors);
+    uint32_t num_tvs = (uint32_t)Vec_Get_Size(term_vectors);
     if (num_tvs == num_terms) {
         TermVector *first_tv = (TermVector*)Vec_Fetch(term_vectors, 0);
         TermVector *last_tv

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -150,11 +150,11 @@ ProximityQuery_Equals_IMP(ProximityQuery *self, Obj *other) {
 String*
 ProximityQuery_To_String_IMP(ProximityQuery *self) {
     ProximityQueryIVARS *const ivars = ProximityQuery_IVARS(self);
-    uint32_t num_terms = Vec_Get_Size(ivars->terms);
+    size_t num_terms = Vec_Get_Size(ivars->terms);
     CharBuf *buf = CB_new(0);
     CB_Cat(buf, ivars->field);
     CB_Cat_Trusted_Utf8(buf, ":\"", 2);
-    for (uint32_t i = 0; i < num_terms; i++) {
+    for (size_t i = 0; i < num_terms; i++) {
         Obj *term = Vec_Fetch(ivars->terms, i);
         String *term_string = Obj_To_String(term);
         CB_Cat(buf, term_string);
@@ -328,7 +328,7 @@ ProximityCompiler_Make_Matcher_IMP(ProximityCompiler *self, SegReader *reader,
     ProximityQueryIVARS *const parent_ivars
         = ProximityQuery_IVARS((ProximityQuery*)ivars->parent);
     Vector *const      terms     = parent_ivars->terms;
-    uint32_t           num_terms = Vec_Get_Size(terms);
+    size_t             num_terms = Vec_Get_Size(terms);
 
     // Bail if there are no terms.
     if (!num_terms) { return NULL; }
@@ -350,7 +350,7 @@ ProximityCompiler_Make_Matcher_IMP(ProximityCompiler *self, SegReader *reader,
 
     // Look up each term.
     Vector  *plists = Vec_new(num_terms);
-    for (uint32_t i = 0; i < num_terms; i++) {
+    for (size_t i = 0; i < num_terms; i++) {
         Obj *term = Vec_Fetch(terms, i);
         PostingList *plist
             = PListReader_Posting_List(plist_reader, parent_ivars->field, term);


### PR DESCRIPTION
The Clownfish API `Vec_Get_Size` has changed from returning `uint32_t` to returning `size_t`.  Adapt Lucy for the effect of this change.

This branch is broken up into commits according to the kind of remedy that was applied at each site, and the associated difficulty of proofing the change.