### PR TITLE
Dereference token_re on older Perls

### DIFF
--- a/perl/xs/Lucy/Analysis/RegexTokenizer.c
+++ b/perl/xs/Lucy/Analysis/RegexTokenizer.c
@@ -58,9 +58,13 @@ lucy_RegexTokenizer_init(lucy_RegexTokenizer *self,
 #if (PERL_VERSION > 10)
     REGEXP *rx = SvRX((SV*)token_re);
 #else
+    if (!SvROK(token_re)) {
+        THROW(CFISH_ERR, "token_re is not a qr// entity");
+    }
+    SV *inner = SvRV(token_re);
     MAGIC *magic = NULL;
-    if (SvMAGICAL((SV*)token_re)) {
-        magic = mg_find((SV*)token_re, PERL_MAGIC_qr);
+    if (SvMAGICAL((SV*)inner)) {
+        magic = mg_find((SV*)inner, PERL_MAGIC_qr);
     }
     if (!magic) {
         THROW(CFISH_ERR, "token_re is not a qr// entity");


### PR DESCRIPTION
Might fix the following CPAN Testers failure:

http://www.cpantesters.org/cpan/report/8c9a1bc2-fa55-11e5-b227-b497ee9ed8df

I'm really puzzled why the old and the new code seem to work on most
setups.

Hopefully fixes LUCY-297.