### PR TITLE
LUCY-295 BitVector size_t ticks

### DIFF
--- a/core/Lucy/Index/BitVecDelDocs.c
+++ b/core/Lucy/Index/BitVecDelDocs.c
@@ -40,9 +40,9 @@ BitVecDelDocs_init(BitVecDelDocs *self, Folder *folder,
         RETHROW(error);
     }
     // Cast away const-ness of buffer as we have no immutable BitVector.
-    int32_t len    = (int32_t)InStream_Length(ivars->instream);
+    int64_t len    = InStream_Length(ivars->instream);
     ivars->bits    = (uint8_t*)InStream_Buf(ivars->instream, len);
-    ivars->cap     = (uint32_t)(len * 8);
+    ivars->cap     = (size_t)(len * 8);
     return self;
 }
 

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -98,7 +98,7 @@ DefDelWriter_init(DefaultDeletionsWriter *self, Schema *schema,
     // Materialize a BitVector of deletions for each segment.
     for (size_t i = 0; i < num_seg_readers; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);
-        BitVector *bit_vec    = BitVec_new(SegReader_Doc_Max(seg_reader));
+        BitVector *bit_vec    = BitVec_new((size_t)SegReader_Doc_Max(seg_reader));
         DeletionsReader *del_reader
             = (DeletionsReader*)SegReader_Fetch(
                   seg_reader, Class_Get_Name(DELETIONSREADER));
@@ -109,7 +109,7 @@ DefDelWriter_init(DefaultDeletionsWriter *self, Schema *schema,
         if (seg_dels) {
             int32_t del;
             while (0 != (del = Matcher_Next(seg_dels))) {
-                BitVec_Set(bit_vec, del);
+                BitVec_Set(bit_vec, (size_t)del);
             }
             DECREF(seg_dels);
         }
@@ -268,8 +268,8 @@ DefDelWriter_Delete_By_Term_IMP(DefaultDeletionsWriter *self,
         // Iterate through postings, marking each doc as deleted.
         if (plist) {
             while (0 != (doc_id = PList_Next(plist))) {
-                num_zapped += !BitVec_Get(bit_vec, doc_id);
-                BitVec_Set(bit_vec, doc_id);
+                num_zapped += !BitVec_Get(bit_vec, (size_t)doc_id);
+                BitVec_Set(bit_vec, (size_t)doc_id);
             }
             if (num_zapped) { ivars->updated[i] = true; }
             DECREF(plist);
@@ -294,8 +294,8 @@ DefDelWriter_Delete_By_Query_IMP(DefaultDeletionsWriter *self, Query *query) {
 
             // Iterate through matches, marking each doc as deleted.
             while (0 != (doc_id = Matcher_Next(matcher))) {
-                num_zapped += !BitVec_Get(bit_vec, doc_id);
-                BitVec_Set(bit_vec, doc_id);
+                num_zapped += !BitVec_Get(bit_vec, (size_t)doc_id);
+                BitVec_Set(bit_vec, (size_t)doc_id);
             }
             if (num_zapped) { ivars->updated[i] = true; }
 
@@ -314,9 +314,9 @@ DefDelWriter_Delete_By_Doc_ID_IMP(DefaultDeletionsWriter *self, int32_t doc_id) 
     int32_t    offset     = I32Arr_Get(ivars->seg_starts, sub_tick);
     int32_t    seg_doc_id = doc_id - offset;
 
-    if (!BitVec_Get(bit_vec, seg_doc_id)) {
+    if (!BitVec_Get(bit_vec, (size_t)seg_doc_id)) {
         ivars->updated[sub_tick] = true;
-        BitVec_Set(bit_vec, seg_doc_id);
+        BitVec_Set(bit_vec, (size_t)seg_doc_id);
     }
 }
 

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -152,8 +152,8 @@ DefDelWriter_Finish_IMP(DefaultDeletionsWriter *self) {
         if (ivars->updated[i]) {
             BitVector *deldocs   = (BitVector*)Vec_Fetch(ivars->bit_vecs, i);
             int32_t    doc_max   = SegReader_Doc_Max(seg_reader);
-            uint32_t   byte_size = (((uint32_t)doc_max + 1) + 7) / 8;
-            uint32_t   new_max   = byte_size * 8 - 1;
+            size_t     byte_size = (((size_t)doc_max + 1) + 7) / 8;
+            size_t     new_max   = byte_size * 8 - 1;
             String    *filename  = S_del_filename(self, seg_reader);
             OutStream *outstream = Folder_Open_Out(folder, filename);
             if (!outstream) { RETHROW(INCREF(Err_get_error())); }
@@ -246,7 +246,7 @@ DefDelWriter_Seg_Del_Count_IMP(DefaultDeletionsWriter *self,
     BitVector *deldocs = tick
                          ? (BitVector*)Vec_Fetch(ivars->bit_vecs, Int_Get_Value(tick))
                          : NULL;
-    return deldocs ? BitVec_Count(deldocs) : 0;
+    return deldocs ? (int32_t)BitVec_Count(deldocs) : 0;
 }
 
 void

--- a/core/Lucy/Object/BitVector.c
+++ b/core/Lucy/Object/BitVector.c
@@ -48,15 +48,15 @@ static const uint32_t BYTE_COUNTS[256] = {
 
 
 BitVector*
-BitVec_new(uint32_t capacity) {
+BitVec_new(size_t capacity) {
     BitVector *self = (BitVector*)Class_Make_Obj(BITVECTOR);
     return BitVec_init(self, capacity);
 }
 
 BitVector*
-BitVec_init(BitVector *self, uint32_t capacity) {
+BitVec_init(BitVector *self, size_t capacity) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
-    const uint32_t byte_size = (capacity + 7) / 8;
+    const size_t byte_size = (capacity + 7) / 8;
 
     // Derive.
     ivars->bits = capacity
@@ -80,7 +80,7 @@ BitVector*
 BitVec_Clone_IMP(BitVector *self) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     BitVector *other = BitVec_new(ivars->cap);
-    uint32_t   byte_size = (ivars->cap + 7) / 8;
+    size_t byte_size = (ivars->cap + 7) / 8;
     BitVectorIVARS *const ovars = BitVec_IVARS(other);
 
     // Forbid inheritance.
@@ -99,7 +99,7 @@ BitVec_Get_Raw_Bits_IMP(BitVector *self) {
     return BitVec_IVARS(self)->bits;
 }
 
-uint32_t
+size_t
 BitVec_Get_Capacity_IMP(BitVector *self) {
     return BitVec_IVARS(self)->cap;
 }
@@ -109,10 +109,10 @@ BitVec_Mimic_IMP(BitVector *self, Obj *other) {
     CERTIFY(other, BITVECTOR);
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     BitVectorIVARS *const ovars = BitVec_IVARS((BitVector*)other);
-    const uint32_t my_byte_size = (ivars->cap + 7) / 8;
-    const uint32_t other_byte_size = (ovars->cap + 7) / 8;
+    const size_t my_byte_size = (ivars->cap + 7) / 8;
+    const size_t other_byte_size = (ovars->cap + 7) / 8;
     if (my_byte_size > other_byte_size) {
-        uint32_t space = my_byte_size - other_byte_size;
+        size_t space = my_byte_size - other_byte_size;
         memset(ivars->bits + other_byte_size, 0, space);
     }
     else if (my_byte_size < other_byte_size) {
@@ -122,7 +122,7 @@ BitVec_Mimic_IMP(BitVector *self, Obj *other) {
 }
 
 void
-BitVec_Grow_IMP(BitVector *self, uint32_t capacity) {
+BitVec_Grow_IMP(BitVector *self, size_t capacity) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     if (capacity > ivars->cap) {
         const size_t old_byte_cap  = (ivars->cap + 7) / 8;
@@ -136,17 +136,17 @@ BitVec_Grow_IMP(BitVector *self, uint32_t capacity) {
 }
 
 void
-BitVec_Set_IMP(BitVector *self, uint32_t tick) {
+BitVec_Set_IMP(BitVector *self, size_t tick) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     if (tick >= ivars->cap) {
-        uint32_t new_cap = (uint32_t)Memory_oversize(tick + 1, 0);
+        size_t new_cap = (size_t)Memory_oversize(tick + 1, 0);
         BitVec_Grow(self, new_cap);
     }
     NumUtil_u1set(ivars->bits, tick);
 }
 
 void
-BitVec_Clear_IMP(BitVector *self, uint32_t tick) {
+BitVec_Clear_IMP(BitVector *self, size_t tick) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     if (tick >= ivars->cap) {
         return;
@@ -162,7 +162,7 @@ BitVec_Clear_All_IMP(BitVector *self) {
 }
 
 bool
-BitVec_Get_IMP(BitVector *self, uint32_t tick) {
+BitVec_Get_IMP(BitVector *self, size_t tick) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     if (tick >= ivars->cap) {
         return false;
@@ -180,7 +180,7 @@ S_first_bit_in_nonzero_byte(uint8_t num) {
 }
 
 int32_t
-BitVec_Next_Hit_IMP(BitVector *self, uint32_t tick) {
+BitVec_Next_Hit_IMP(BitVector *self, size_t tick) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     size_t byte_size = (ivars->cap + 7) / 8;
     uint8_t *const limit = ivars->bits + byte_size;
@@ -219,9 +219,9 @@ BitVec_And_IMP(BitVector *self, const BitVector *other) {
     const BitVectorIVARS *const ovars = BitVec_IVARS((BitVector*)other);
     uint8_t *bits_a = ivars->bits;
     uint8_t *bits_b = ovars->bits;
-    const uint32_t min_cap = ivars->cap < ovars->cap
-                             ? ivars->cap
-                             : ovars->cap;
+    const size_t min_cap = ivars->cap < ovars->cap
+                           ? ivars->cap
+                           : ovars->cap;
     const size_t byte_size = (min_cap + 7) / 8;
     uint8_t *const limit = bits_a + byte_size;
 
@@ -253,7 +253,7 @@ S_do_or_or_xor(BitVector *self, const BitVector *other, int operation) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     const BitVectorIVARS *const ovars = BitVec_IVARS((BitVector*)other);
     uint8_t *bits_a, *bits_b;
-    uint32_t max_cap, min_cap;
+    size_t max_cap, min_cap;
     uint8_t *limit;
     double byte_size;
 
@@ -293,8 +293,8 @@ S_do_or_or_xor(BitVector *self, const BitVector *other, int operation) {
 
     // Copy remaining bits if other is bigger than self.
     if (ovars->cap > min_cap) {
-        const double other_byte_size = (ovars->cap + 7) / 8;
-        const size_t bytes_to_copy = (size_t)(other_byte_size - byte_size);
+        const size_t other_byte_size = (ovars->cap + 7) / 8;
+        const size_t bytes_to_copy = other_byte_size - byte_size;
         memcpy(bits_a, bits_b, bytes_to_copy);
     }
 }
@@ -305,9 +305,9 @@ BitVec_And_Not_IMP(BitVector *self, const BitVector *other) {
     const BitVectorIVARS *const ovars = BitVec_IVARS((BitVector*)other);
     uint8_t *bits_a = ivars->bits;
     uint8_t *bits_b = ovars->bits;
-    const uint32_t min_cap = ivars->cap < ovars->cap
-                             ? ivars->cap
-                             : ovars->cap;
+    const size_t min_cap = ivars->cap < ovars->cap
+                           ? ivars->cap
+                           : ovars->cap;
     const size_t byte_size = (min_cap + 7) / 8;
     uint8_t *const limit = bits_a + byte_size;
 
@@ -319,20 +319,20 @@ BitVec_And_Not_IMP(BitVector *self, const BitVector *other) {
 }
 
 void
-BitVec_Flip_IMP(BitVector *self, uint32_t tick) {
+BitVec_Flip_IMP(BitVector *self, size_t tick) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
     if (tick >= ivars->cap) {
-        uint32_t new_cap = (uint32_t)Memory_oversize(tick + 1, 0);
+        size_t new_cap = Memory_oversize(tick + 1, 0);
         BitVec_Grow(self, new_cap);
     }
     NumUtil_u1flip(ivars->bits, tick);
 }
 
 void
-BitVec_Flip_Block_IMP(BitVector *self, uint32_t offset, uint32_t length) {
+BitVec_Flip_Block_IMP(BitVector *self, size_t offset, size_t length) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
-    uint32_t first = offset;
-    uint32_t last  = offset + length - 1;
+    size_t first = offset;
+    size_t last  = offset + length - 1;
 
     // Bail if there's nothing to flip.
     if (!length) { return; }
@@ -356,8 +356,8 @@ BitVec_Flip_Block_IMP(BitVector *self, uint32_t offset, uint32_t length) {
     }
     // They must be multiples of 8, then.
     else {
-        const uint32_t start_tick = first >> 3;
-        const uint32_t limit_tick = last  >> 3;
+        const size_t start_tick = first >> 3;
+        const size_t limit_tick = last  >> 3;
         uint8_t *bits  = ivars->bits + start_tick;
         uint8_t *limit = ivars->bits + limit_tick;
 
@@ -371,10 +371,10 @@ BitVec_Flip_Block_IMP(BitVector *self, uint32_t offset, uint32_t length) {
     }
 }
 
-uint32_t
+size_t
 BitVec_Count_IMP(BitVector *self) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
-    uint32_t count = 0;
+    size_t count = 0;
     const size_t byte_size = (ivars->cap + 7) / 8;
     uint8_t *ptr = ivars->bits;
     uint8_t *const limit = ptr + byte_size;
@@ -389,9 +389,9 @@ BitVec_Count_IMP(BitVector *self) {
 I32Array*
 BitVec_To_Array_IMP(BitVector *self) {
     BitVectorIVARS *const ivars = BitVec_IVARS(self);
-    uint32_t        count     = BitVec_Count(self);
-    uint32_t        num_left  = count;
-    const uint32_t  capacity  = ivars->cap;
+    size_t          count     = BitVec_Count(self);
+    size_t          num_left  = count;
+    const size_t    capacity  = ivars->cap;
     uint32_t *const array     = (uint32_t*)CALLOCATE(count, sizeof(uint32_t));
     const size_t    byte_size = (ivars->cap + 7) / 8;
     uint8_t *const  bits      = ivars->bits;

--- a/core/Lucy/Object/BitVector.cfh
+++ b/core/Lucy/Object/BitVector.cfh
@@ -24,7 +24,7 @@ parcel Lucy;
 public class Lucy::Object::BitVector nickname BitVec
     inherits Clownfish::Obj {
 
-    uint32_t  cap;
+    size_t  cap;
     uint8_t  *bits;
 
     /** Create a new BitVector.
@@ -33,7 +33,7 @@ public class Lucy::Object::BitVector nickname BitVec
      * able to hold.
      */
     public inert incremented BitVector*
-    new(uint32_t capacity = 0);
+    new(size_t capacity = 0);
 
     /** Initialize a BitVector.
      *
@@ -41,7 +41,7 @@ public class Lucy::Object::BitVector nickname BitVec
      * able to hold.
      */
     public inert BitVector*
-    init(BitVector *self, uint32_t capacity = 0);
+    init(BitVector *self, size_t capacity = 0);
 
     /** Return true if the bit at `tick` has been set, false if it
      * hasn't (regardless of whether it lies within the bounds of the
@@ -50,14 +50,14 @@ public class Lucy::Object::BitVector nickname BitVec
      * @param tick The requested bit.
      */
     public bool
-    Get(BitVector *self, uint32_t tick);
+    Get(BitVector *self, size_t tick);
 
     /** Set the bit at `tick` to 1.
      *
      * @param tick The bit to be set.
      */
     public void
-    Set(BitVector *self, uint32_t tick);
+    Set(BitVector *self, size_t tick);
 
     /** Accessor for the BitVector's underlying bit array.
      */
@@ -66,21 +66,21 @@ public class Lucy::Object::BitVector nickname BitVec
 
     /** Accessor for capacity.
      */
-    uint32_t
+    size_t
     Get_Capacity(BitVector *self);
 
     /** Returns the next set bit equal to or greater than `tick`,
      * or -1 if no such bit exists.
      */
     public int32_t
-    Next_Hit(BitVector *self, uint32_t tick);
+    Next_Hit(BitVector *self, size_t tick);
 
     /** Clear the indicated bit. (i.e. set it to 0).
      *
      * @param tick The bit to be cleared.
      */
     public void
-    Clear(BitVector *self, uint32_t tick);
+    Clear(BitVector *self, size_t tick);
 
     /** Clear all bits.
      */
@@ -93,7 +93,7 @@ public class Lucy::Object::BitVector nickname BitVec
      * @param capacity Least number of bits the BitVector should accomodate.
      */
     public void
-    Grow(BitVector *self, uint32_t capacity);
+    Grow(BitVector *self, size_t capacity);
 
     /** Modify the contents of this BitVector so that it has the same bits set
      * as `other`.
@@ -139,7 +139,7 @@ public class Lucy::Object::BitVector nickname BitVec
      * @param tick The bit to invert.
      */
     public void
-    Flip(BitVector *self, uint32_t tick);
+    Flip(BitVector *self, size_t tick);
 
     /** Invert each bit within a contiguous block.
      *
@@ -147,11 +147,11 @@ public class Lucy::Object::BitVector nickname BitVec
      * @param length The number of bits to flip.
      */
     public void
-    Flip_Block(BitVector *self, uint32_t offset, uint32_t length);
+    Flip_Block(BitVector *self, size_t offset, size_t length);
 
     /** Return a count of the number of set bits.
      */
-    public uint32_t
+    public size_t
     Count(BitVector *self);
 
     /** Return an array where each element represents a set bit.

--- a/core/Lucy/Search/BitVecMatcher.c
+++ b/core/Lucy/Search/BitVecMatcher.c
@@ -44,14 +44,15 @@ BitVecMatcher_Destroy_IMP(BitVecMatcher *self) {
 int32_t
 BitVecMatcher_Next_IMP(BitVecMatcher *self) {
     BitVecMatcherIVARS *const ivars = BitVecMatcher_IVARS(self);
-    ivars->doc_id = BitVec_Next_Hit(ivars->bit_vec, ivars->doc_id + 1);
+    ivars->doc_id
+        = BitVec_Next_Hit(ivars->bit_vec, (size_t)(ivars->doc_id + 1));
     return ivars->doc_id == -1 ? 0 : ivars->doc_id;
 }
 
 int32_t
 BitVecMatcher_Advance_IMP(BitVecMatcher *self, int32_t target) {
     BitVecMatcherIVARS *const ivars = BitVecMatcher_IVARS(self);
-    ivars->doc_id = BitVec_Next_Hit(ivars->bit_vec, target);
+    ivars->doc_id = BitVec_Next_Hit(ivars->bit_vec, (size_t)target);
     return ivars->doc_id == -1 ? 0 : ivars->doc_id;
 }
 

--- a/core/Lucy/Search/Collector.c
+++ b/core/Lucy/Search/Collector.c
@@ -88,7 +88,7 @@ BitColl_Collect_IMP(BitCollector *self, int32_t doc_id) {
     BitCollectorIVARS *const ivars = BitColl_IVARS(self);
 
     // Add the doc_id to the BitVector.
-    BitVec_Set(ivars->bit_vec, (ivars->base + doc_id));
+    BitVec_Set(ivars->bit_vec, (size_t)(ivars->base + doc_id));
 }
 
 bool

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -376,7 +376,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
             // Set initial positions from first term.
             I32Array *positions = TV_Get_Positions(term_vector);
             for (size_t j = I32Arr_Get_Size(positions); j > 0; j--) {
-                BitVec_Set(posit_vec, (uint32_t)I32Arr_Get(positions, j - 1));
+                BitVec_Set(posit_vec, (size_t)I32Arr_Get(positions, j - 1));
             }
         }
         else {
@@ -387,7 +387,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
             for (size_t j = I32Arr_Get_Size(positions); j > 0; j--) {
                 int32_t pos = I32Arr_Get(positions, j - 1) - (int32_t)i;
                 if (pos >= 0) {
-                    BitVec_Set(other_posit_vec, pos);
+                    BitVec_Set(other_posit_vec, (size_t)pos);
                 }
             }
             BitVec_And(posit_vec, other_posit_vec);

--- a/core/Lucy/Test/Search/TestSeriesMatcher.c
+++ b/core/Lucy/Test/Search/TestSeriesMatcher.c
@@ -42,12 +42,12 @@ S_make_series_matcher(I32Array *doc_ids, I32Array *offsets, int32_t doc_max) {
         int32_t max    = i == num_matchers - 1
                          ? doc_max + 1
                          : I32Arr_Get(offsets, i + 1);
-        BitVector *bit_vec = BitVec_new(max - offset);
+        BitVector *bit_vec = BitVec_new((size_t)(max - offset));
         while (tick < num_doc_ids) {
             int32_t doc_id = I32Arr_Get(doc_ids, tick);
             if (doc_id > max) { break; }
             else               { tick++; }
-            BitVec_Set(bit_vec, doc_id - offset);
+            BitVec_Set(bit_vec, (size_t)(doc_id - offset));
         }
         Vec_Push(matchers, (Obj*)BitVecMatcher_new(bit_vec));
         DECREF(bit_vec);

--- a/core/LucyX/Search/FilterMatcher.c
+++ b/core/LucyX/Search/FilterMatcher.c
@@ -55,7 +55,7 @@ FilterMatcher_Next_IMP(FilterMatcher* self) {
             ivars->doc_id--;
             return 0;
         }
-    } while (!BitVec_Get(ivars->bits, ivars->doc_id));
+    } while (!BitVec_Get(ivars->bits, (size_t)ivars->doc_id));
     return ivars->doc_id;
 }
 

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -405,7 +405,7 @@ ProximityCompiler_Highlight_Spans_IMP(ProximityCompiler *self,
             // Set initial positions from first term.
             I32Array *positions = TV_Get_Positions(term_vector);
             for (size_t j = I32Arr_Get_Size(positions); j > 0; j--) {
-                BitVec_Set(posit_vec, (uint32_t)I32Arr_Get(positions, j - 1));
+                BitVec_Set(posit_vec, (size_t)I32Arr_Get(positions, j - 1));
             }
         }
         else {
@@ -416,7 +416,7 @@ ProximityCompiler_Highlight_Spans_IMP(ProximityCompiler *self,
             for (size_t j = I32Arr_Get_Size(positions); j > 0; j--) {
                 int32_t pos = I32Arr_Get(positions, j - 1) - (int32_t)i;
                 if (pos >= 0) {
-                    BitVec_Set(other_posit_vec, pos);
+                    BitVec_Set(other_posit_vec, (size_t)pos);
                 }
             }
             BitVec_And(posit_vec, other_posit_vec);

--- a/go/lucy/object.go
+++ b/go/lucy/object.go
@@ -28,11 +28,11 @@ import "git-wip-us.apache.org/repos/asf/lucy-clownfish.git/runtime/go/clownfish"
 
 func (bv *BitVectorIMP) ToArray() []bool {
 	cap := bv.getCapacity()
-	if cap != uint32(int(cap)) {
+	if cap != uintptr(int(cap)) {
 		panic(fmt.Sprintf("Capacity of range: %d", cap))
 	}
 	bools := make([]bool, int(cap))
-	for i := uint32(0); i < cap; i++ {
+	for i := uintptr(0); i < cap; i++ {
 		bools[i] = bv.Get(i)
 	}
 	return bools


### PR DESCRIPTION
Change BitVector to use `size_t` instead of `uint32_t` to address bits in the array.