### PR TITLE
LUCY-302 NumUtils warnings

### DIFF
--- a/core/Lucy/Index/SortCache.c
+++ b/core/Lucy/Index/SortCache.c
@@ -71,9 +71,9 @@ SortCache_Ordinal_IMP(SortCache *self, int32_t doc_id) {
         THROW(ERR, "Out of range: %i32 > %i32", doc_id, ivars->doc_max);
     }
     switch (ivars->ord_width) {
-        case 1: return NumUtil_u1get(ivars->ords, doc_id);
-        case 2: return NumUtil_u2get(ivars->ords, doc_id);
-        case 4: return NumUtil_u4get(ivars->ords, doc_id);
+        case 1: return NumUtil_u1get(ivars->ords, (uint32_t)doc_id);
+        case 2: return NumUtil_u2get(ivars->ords, (uint32_t)doc_id);
+        case 4: return NumUtil_u4get(ivars->ords, (uint32_t)doc_id);
         case 8: {
                 uint8_t *ints = (uint8_t*)ivars->ords;
                 return ints[doc_id];

--- a/core/Lucy/Index/SortFieldWriter.c
+++ b/core/Lucy/Index/SortFieldWriter.c
@@ -223,14 +223,14 @@ static void
 S_write_ord(void *ords, int32_t width, int32_t doc_id, int32_t ord) {
     switch (width) {
         case 1:
-            if (ord) { NumUtil_u1set(ords, doc_id); }
-            else     { NumUtil_u1clear(ords, doc_id); }
+            if (ord) { NumUtil_u1set(ords, (uint32_t)doc_id); }
+            else     { NumUtil_u1clear(ords, (uint32_t)doc_id); }
             break;
         case 2:
-            NumUtil_u2set(ords, doc_id, ord);
+            NumUtil_u2set(ords, (uint32_t)doc_id, (uint8_t)ord);
             break;
         case 4:
-            NumUtil_u4set(ords, doc_id, ord);
+            NumUtil_u4set(ords, (uint32_t)doc_id, (uint8_t)ord);
             break;
         case 8: {
                 uint8_t *ints = (uint8_t*)ords;

--- a/core/Lucy/Test/Util/TestNumberUtils.c
+++ b/core/Lucy/Test/Util/TestNumberUtils.c
@@ -44,15 +44,14 @@ test_u1(TestBatchRunner *runner) {
         if (ints[i]) { NumUtil_u1set(bits, i); }
     }
     for (size_t i = 0; i < count; i++) {
-        TEST_INT_EQ(runner, NumUtil_u1get(bits, i), (long)ints[i],
-                    "u1 set/get");
+        TEST_UINT_EQ(runner, NumUtil_u1get(bits, i), ints[i], "u1 set/get");
     }
 
     for (size_t i = 0; i < count; i++) {
         NumUtil_u1flip(bits, i);
     }
     for (size_t i = 0; i < count; i++) {
-        TEST_INT_EQ(runner, NumUtil_u1get(bits, i), !ints[i], "u1 flip");
+        TEST_UINT_EQ(runner, NumUtil_u1get(bits, i), !ints[i], "u1 flip");
     }
 
     FREEMEM(bits);
@@ -69,7 +68,7 @@ test_u2(TestBatchRunner *runner) {
         NumUtil_u2set(bits, i, (uint8_t)ints[i]);
     }
     for (size_t i = 0; i < count; i++) {
-        TEST_INT_EQ(runner, NumUtil_u2get(bits, i), (long)ints[i], "u2");
+        TEST_UINT_EQ(runner, NumUtil_u2get(bits, i), ints[i], "u2");
     }
 
     FREEMEM(bits);
@@ -86,7 +85,7 @@ test_u4(TestBatchRunner *runner) {
         NumUtil_u4set(bits, i, (uint8_t)ints[i]);
     }
     for (size_t i = 0; i < count; i++) {
-        TEST_INT_EQ(runner, NumUtil_u4get(bits, i), (long)ints[i], "u4");
+        TEST_UINT_EQ(runner, NumUtil_u4get(bits, i), ints[i], "u4");
     }
 
     FREEMEM(bits);

--- a/core/Lucy/Util/NumberUtils.cfh
+++ b/core/Lucy/Util/NumberUtils.cfh
@@ -441,7 +441,7 @@ static CFISH_INLINE bool
 lucy_NumUtil_u1get(const void *array, uint32_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
     const uint32_t byte_offset = tick >> 3;
-    const uint8_t  mask        = 1 << (tick & 0x7);
+    const unsigned mask        = 1 << (tick & 0x7);
     return !((u8bits[byte_offset] & mask) == 0);
 }
 
@@ -449,7 +449,7 @@ static CFISH_INLINE void
 lucy_NumUtil_u1set(void *array, uint32_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
     const uint32_t byte_offset = tick >> 3;
-    const uint8_t  mask        = 1 << (tick & 0x7);
+    const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] |= mask;
 }
 
@@ -457,7 +457,7 @@ static CFISH_INLINE void
 lucy_NumUtil_u1clear(void *array, uint32_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
     const uint32_t byte_offset = tick >> 3;
-    const uint8_t  mask        = 1 << (tick & 0x7);
+    const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] &= ~mask;
 }
 
@@ -465,7 +465,7 @@ static CFISH_INLINE void
 lucy_NumUtil_u1flip(void *array, uint32_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
     const uint32_t byte_offset = tick >> 3;
-    const uint8_t  mask        = 1 << (tick & 0x7);
+    const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] ^= mask;
 }
 
@@ -480,8 +480,8 @@ lucy_NumUtil_u2get(const void *array, uint32_t tick) {
 static CFISH_INLINE void
 lucy_NumUtil_u2set(void *array, uint32_t tick, uint8_t value) {
     uint8_t *ints     = (uint8_t*)array;
-    int      shift    = 2 * (tick & 0x3);
-    uint8_t  mask     = 0x3 << shift;
+    unsigned shift    = 2 * (tick & 0x3);
+    unsigned mask     = (unsigned)0x3 << shift;
     uint8_t  new_val  = value & 0x3;
     uint8_t  new_bits = new_val << shift;
     ints[(tick >> 2)]  = (ints[(tick >> 2)] & ~mask) | new_bits;
@@ -499,8 +499,8 @@ lucy_NumUtil_u4get(const void *array, uint32_t tick) {
 static CFISH_INLINE void
 lucy_NumUtil_u4set(void *array, uint32_t tick, uint8_t value) {
     uint8_t  *ints     = (uint8_t*)array;
-    int       shift    = 4 * (tick & 0x1);
-    uint8_t   mask     = 0xF << shift;
+    unsigned  shift    = 4 * (tick & 0x1);
+    unsigned  mask     = (unsigned)0xF << shift;
     uint8_t   new_val  = value & 0xF;
     uint8_t   new_bits = new_val << shift;
     ints[(tick >> 1)]  = (ints[(tick >> 1)] & ~mask) | new_bits;

--- a/core/Lucy/Util/NumberUtils.cfh
+++ b/core/Lucy/Util/NumberUtils.cfh
@@ -249,8 +249,7 @@ lucy_NumUtil_encode_bigend_u64(uint64_t value, void *dest_ptr) {
 static CFISH_INLINE uint16_t
 lucy_NumUtil_decode_bigend_u16(const void *source) {
     const uint8_t *const buf = (const uint8_t*)source;
-    return  ((uint16_t)buf[0] << 8) |
-            ((uint16_t)buf[1]);
+    return  (uint16_t)((buf[0] << 8) | buf[1]);
 }
 
 static CFISH_INLINE uint32_t

--- a/core/Lucy/Util/NumberUtils.cfh
+++ b/core/Lucy/Util/NumberUtils.cfh
@@ -483,7 +483,7 @@ lucy_NumUtil_u2set(void *array, uint32_t tick, uint8_t value) {
     unsigned shift    = 2 * (tick & 0x3);
     unsigned mask     = (unsigned)0x3 << shift;
     uint8_t  new_val  = value & 0x3;
-    uint8_t  new_bits = new_val << shift;
+    uint8_t  new_bits = (uint8_t)(new_val << shift);
     ints[(tick >> 2)]  = (ints[(tick >> 2)] & ~mask) | new_bits;
 }
 
@@ -502,7 +502,7 @@ lucy_NumUtil_u4set(void *array, uint32_t tick, uint8_t value) {
     unsigned  shift    = 4 * (tick & 0x1);
     unsigned  mask     = (unsigned)0xF << shift;
     uint8_t   new_val  = value & 0xF;
-    uint8_t   new_bits = new_val << shift;
+    uint8_t   new_bits = (uint8_t)(new_val << shift);
     ints[(tick >> 1)]  = (ints[(tick >> 1)] & ~mask) | new_bits;
 }
 

--- a/core/Lucy/Util/NumberUtils.cfh
+++ b/core/Lucy/Util/NumberUtils.cfh
@@ -337,7 +337,7 @@ lucy_NumUtil_encode_cu32(uint32_t value, char **out_buf) {
     uint8_t   buf[LUCY_NUMUTIL_CU32_MAX_BYTES];
     uint8_t  *const limit = buf + sizeof(buf);
     uint8_t  *ptr         = limit - 1;
-    int       num_bytes;
+    ptrdiff_t num_bytes;
     /* Write last byte first, which has no continue bit. */
     *ptr = value & 0x7f;
     value >>= 7;
@@ -347,7 +347,7 @@ lucy_NumUtil_encode_cu32(uint32_t value, char **out_buf) {
         value >>= 7;
     }
     num_bytes = limit - ptr;
-    memcpy(*out_buf, ptr, num_bytes);
+    memcpy(*out_buf, ptr, (size_t)num_bytes);
     *out_buf += num_bytes;
 }
 
@@ -361,7 +361,7 @@ lucy_NumUtil_encode_cu64(uint64_t value, char **out_buf) {
     uint8_t   buf[LUCY_NUMUTIL_CU64_MAX_BYTES];
     uint8_t  *const limit = buf + sizeof(buf);
     uint8_t  *ptr         = limit - 1;
-    int       num_bytes;
+    ptrdiff_t num_bytes;
     /* Write last byte first, which has no continue bit. */
     *ptr = value & 0x7f;
     value >>= 7;
@@ -371,7 +371,7 @@ lucy_NumUtil_encode_cu64(uint64_t value, char **out_buf) {
         value >>= 7;
     }
     num_bytes = limit - ptr;
-    memcpy(*out_buf, ptr, num_bytes);
+    memcpy(*out_buf, ptr, (size_t)num_bytes);
     *out_buf += num_bytes;
 }
 

--- a/core/Lucy/Util/NumberUtils.cfh
+++ b/core/Lucy/Util/NumberUtils.cfh
@@ -153,49 +153,49 @@ inert class Lucy::Util::NumberUtils nickname NumUtil {
      * bit at `tick` is set, false otherwise.
      */
     inert inline bool
-    u1get(const void *array, uint32_t tick);
+    u1get(const void *array, size_t tick);
 
     /** Interpret `array` as an array of bits; set the bit at
      * `tick`.
      */
     inert inline void
-    u1set(void *array, uint32_t tick);
+    u1set(void *array, size_t tick);
 
     /** Interpret `array` as an array of bits; clear the bit at
      * `tick`.
      */
     inert inline void
-    u1clear(void *array, uint32_t tick);
+    u1clear(void *array, size_t tick);
 
     /** Interpret `array` as an array of bits; flip the bit at
      * `tick`.
      */
     inert inline void
-    u1flip(void *array, uint32_t tick);
+    u1flip(void *array, size_t tick);
 
     /** Interpret `array` as an array of two-bit integers; return
      * the value at `tick`.
      */
     inert inline uint8_t
-    u2get(const void *array, uint32_t tick);
+    u2get(const void *array, size_t tick);
 
     /** Interpret `array` as an array of two-bit integers; set the
      * element at `tick` to `value`.
      */
     inert inline void
-    u2set(void *array, uint32_t tick, uint8_t value);
+    u2set(void *array, size_t tick, uint8_t value);
 
     /** Interpret `array` as an array of four-bit integers; return
      * the value at `tick`.
      */
     inert inline uint8_t
-    u4get(const void *array, uint32_t tick);
+    u4get(const void *array, size_t tick);
 
     /** Interpret `array` as an array of four-bit integers; set the
      * element at `tick` to `value`.
      */
     inert inline void
-    u4set(void *array, uint32_t tick, uint8_t value);
+    u4set(void *array, size_t tick, uint8_t value);
 }
 
 __C__
@@ -437,39 +437,39 @@ lucy_NumUtil_skip_cint(const char **source_ptr) {
 }
 
 static CFISH_INLINE bool
-lucy_NumUtil_u1get(const void *array, uint32_t tick) {
+lucy_NumUtil_u1get(const void *array, size_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
-    const uint32_t byte_offset = tick >> 3;
+    const size_t   byte_offset = tick >> 3;
     const unsigned mask        = 1 << (tick & 0x7);
     return !((u8bits[byte_offset] & mask) == 0);
 }
 
 static CFISH_INLINE void
-lucy_NumUtil_u1set(void *array, uint32_t tick) {
+lucy_NumUtil_u1set(void *array, size_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
-    const uint32_t byte_offset = tick >> 3;
+    const size_t   byte_offset = tick >> 3;
     const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] |= mask;
 }
 
 static CFISH_INLINE void
-lucy_NumUtil_u1clear(void *array, uint32_t tick) {
+lucy_NumUtil_u1clear(void *array, size_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
-    const uint32_t byte_offset = tick >> 3;
+    const size_t   byte_offset = tick >> 3;
     const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] &= ~mask;
 }
 
 static CFISH_INLINE void
-lucy_NumUtil_u1flip(void *array, uint32_t tick) {
+lucy_NumUtil_u1flip(void *array, size_t tick) {
     uint8_t *const u8bits      = (uint8_t*)array;
-    const uint32_t byte_offset = tick >> 3;
+    const size_t   byte_offset = tick >> 3;
     const unsigned mask        = 1 << (tick & 0x7);
     u8bits[byte_offset] ^= mask;
 }
 
 static CFISH_INLINE uint8_t
-lucy_NumUtil_u2get(const void *array, uint32_t tick) {
+lucy_NumUtil_u2get(const void *array, size_t tick) {
     uint8_t *ints  = (uint8_t*)array;
     uint8_t  byte  = ints[(tick >> 2)];
     int      shift = 2 * (tick & 0x3);
@@ -477,7 +477,7 @@ lucy_NumUtil_u2get(const void *array, uint32_t tick) {
 }
 
 static CFISH_INLINE void
-lucy_NumUtil_u2set(void *array, uint32_t tick, uint8_t value) {
+lucy_NumUtil_u2set(void *array, size_t tick, uint8_t value) {
     uint8_t *ints     = (uint8_t*)array;
     unsigned shift    = 2 * (tick & 0x3);
     unsigned mask     = (unsigned)0x3 << shift;
@@ -488,7 +488,7 @@ lucy_NumUtil_u2set(void *array, uint32_t tick, uint8_t value) {
 
 
 static CFISH_INLINE uint8_t
-lucy_NumUtil_u4get(const void *array, uint32_t tick) {
+lucy_NumUtil_u4get(const void *array, size_t tick) {
     uint8_t *ints  = (uint8_t*)array;
     uint8_t  byte  = ints[(tick >> 1)];
     int      shift = 4 * (tick & 1);
@@ -496,7 +496,7 @@ lucy_NumUtil_u4get(const void *array, uint32_t tick) {
 }
 
 static CFISH_INLINE void
-lucy_NumUtil_u4set(void *array, uint32_t tick, uint8_t value) {
+lucy_NumUtil_u4set(void *array, size_t tick, uint8_t value) {
     uint8_t  *ints     = (uint8_t*)array;
     unsigned  shift    = 4 * (tick & 0x1);
     unsigned  mask     = (unsigned)0xF << shift;


### PR DESCRIPTION
In NumberUtils.cfh:

* Widen the array index type for addressing 1-bit, 2-bit, and 4-bit arrays.
* Address a few (false positive) compiler warnings from `-Wconversion`.