### PR TITLE
LUCY-295 Misc int type fixes, part 2

### DIFF
--- a/core/Lucy/Highlight/HeatMap.c
+++ b/core/Lucy/Highlight/HeatMap.c
@@ -170,7 +170,8 @@ HeatMap_Calc_Proximity_Boost_IMP(HeatMap *self, Span *span1, Span *span2) {
         return 0.0f;
     }
     else {
-        float factor = (ivars->window - distance) / (float)ivars->window;
+        float factor
+            = ((int32_t)ivars->window - distance) / (float)ivars->window;
         // Damp boost with greater distance.
         factor *= factor;
         return factor * (Span_Get_Weight(lower) + Span_Get_Weight(upper));

--- a/core/Lucy/Highlight/HeatMap.c
+++ b/core/Lucy/Highlight/HeatMap.c
@@ -144,7 +144,7 @@ HeatMap_Flatten_Spans_IMP(HeatMap *self, Vector *spans) {
         dest_tick = 0;
         for (size_t i = 0; i < num_raw_flattened; i++) {
             Span *span = (Span*)Vec_Fetch(flattened, i);
-            if (Span_Get_Weight(span)) {
+            if (Span_Get_Weight(span) != 0.0f) {
                 Vec_Store(flattened, dest_tick++, INCREF(span));
             }
         }

--- a/core/Lucy/Index/DocVector.c
+++ b/core/Lucy/Index/DocVector.c
@@ -144,7 +144,7 @@ S_extract_tv_cache(Blob *field_buf) {
             NumUtil_skip_cint(&tv_string);
             NumUtil_skip_cint(&tv_string);
         }
-        len = tv_string - bookmark_ptr;
+        len = (size_t)(tv_string - bookmark_ptr);
 
         // Store the $text => $posdata pair in the output hash.
         String *text = BB_Trusted_Utf8_To_String(text_buf);

--- a/core/Lucy/Index/LexiconReader.c
+++ b/core/Lucy/Index/LexiconReader.c
@@ -243,7 +243,7 @@ uint32_t
 DefLexReader_Doc_Freq_IMP(DefaultLexiconReader *self, String *field,
                           Obj *term) {
     TermInfo *tinfo = S_find_tinfo(self, field, term);
-    return tinfo ? TInfo_Get_Doc_Freq(tinfo) : 0;
+    return tinfo ? (uint32_t)TInfo_Get_Doc_Freq(tinfo) : 0;
 }
 
 

--- a/core/Lucy/Index/Posting/MatchPosting.c
+++ b/core/Lucy/Index/Posting/MatchPosting.c
@@ -70,7 +70,7 @@ MatchPost_Destroy_IMP(MatchPosting *self) {
 
 int32_t
 MatchPost_Get_Freq_IMP(MatchPosting *self) {
-    return MatchPost_IVARS(self)->freq;
+    return (int32_t)MatchPost_IVARS(self)->freq;
 }
 
 void

--- a/core/Lucy/Index/Posting/RichPosting.c
+++ b/core/Lucy/Index/Posting/RichPosting.c
@@ -129,15 +129,15 @@ RichPost_Add_Inversion_To_Pool_IMP(RichPosting *self, PostingPool *post_pool,
         RawPostingIVARS *const raw_post_ivars = RawPost_IVARS(raw_posting);
         char *const start = raw_post_ivars->blob + token_ivars->len;
         char *dest = start;
-        uint32_t last_prox = 0;
+        int32_t last_prox = 0;
 
         // Positions and boosts.
         for (uint32_t i = 0; i < freq; i++) {
             TokenIVARS *const t_ivars = Token_IVARS(tokens[i]);
-            const uint32_t prox_delta = t_ivars->pos - last_prox;
+            const int32_t prox_delta = t_ivars->pos - last_prox;
             const float boost = field_boost * t_ivars->boost;
 
-            NumUtil_encode_cu32(prox_delta, &dest);
+            NumUtil_encode_ci32(prox_delta, &dest);
             last_prox = t_ivars->pos;
 
             *((uint8_t*)dest) = Sim_Encode_Norm(sim, boost);

--- a/core/Lucy/Index/Posting/ScorePosting.c
+++ b/core/Lucy/Index/Posting/ScorePosting.c
@@ -100,7 +100,7 @@ ScorePost_Add_Inversion_To_Pool_IMP(ScorePosting *self,
         RawPostingIVARS *const raw_post_ivars = RawPost_IVARS(raw_posting);
         char *const start  = raw_post_ivars->blob + token_ivars->len;
         char *dest         = start;
-        uint32_t last_prox = 0;
+        int32_t last_prox = 0;
 
         // Field_boost.
         *((uint8_t*)dest) = field_boost_byte;
@@ -109,8 +109,8 @@ ScorePost_Add_Inversion_To_Pool_IMP(ScorePosting *self,
         // Positions.
         for (uint32_t i = 0; i < freq; i++) {
             TokenIVARS *const t_ivars = Token_IVARS(tokens[i]);
-            const uint32_t prox_delta = t_ivars->pos - last_prox;
-            NumUtil_encode_cu32(prox_delta, &dest);
+            const int32_t prox_delta = t_ivars->pos - last_prox;
+            NumUtil_encode_ci32(prox_delta, &dest);
             last_prox = t_ivars->pos;
         }
 

--- a/core/Lucy/Index/PostingListWriter.c
+++ b/core/Lucy/Index/PostingListWriter.c
@@ -36,7 +36,7 @@
 #include "Lucy/Store/OutStream.h"
 #include "Lucy/Util/MemoryPool.h"
 
-static size_t default_mem_thresh = 0x1000000;
+static uint32_t default_mem_thresh = 0x1000000;
 
 int32_t PListWriter_current_file_format = 1;
 
@@ -129,7 +129,7 @@ PListWriter_Destroy_IMP(PostingListWriter *self) {
 }
 
 void
-PListWriter_set_default_mem_thresh(size_t mem_thresh) {
+PListWriter_set_default_mem_thresh(uint32_t mem_thresh) {
     default_mem_thresh = mem_thresh;
 }
 

--- a/core/Lucy/Index/PostingListWriter.cfh
+++ b/core/Lucy/Index/PostingListWriter.cfh
@@ -45,7 +45,7 @@ class Lucy::Index::PostingListWriter nickname PListWriter
 
     /** Test only. */
     inert void
-    set_default_mem_thresh(size_t mem_thresh);
+    set_default_mem_thresh(uint32_t mem_thresh);
 
     void
     Add_Inverted_Doc(PostingListWriter *self, Inverter *inverter,

--- a/core/Lucy/Index/PostingPool.c
+++ b/core/Lucy/Index/PostingPool.c
@@ -483,7 +483,7 @@ PostPool_Refill_IMP(PostingPool *self) {
         if (ivars->post_count == 0) {
             // Read a term.
             if (Lex_Next(lexicon)) {
-                ivars->post_count = Lex_Doc_Freq(lexicon);
+                ivars->post_count = (uint32_t)Lex_Doc_Freq(lexicon);
                 term_text = (String*)Lex_Get_Term(lexicon);
                 if (term_text && !Obj_is_a((Obj*)term_text, STRING)) {
                     THROW(ERR, "Only String terms are supported for now");

--- a/core/Lucy/Index/PostingPool.c
+++ b/core/Lucy/Index/PostingPool.c
@@ -155,7 +155,12 @@ PostPool_Compare_IMP(PostingPool *self, Obj **ptr_a, Obj **ptr_b) {
 
     if (comparison == 0) {
         // If a is a substring of b, it's less than b, so return a neg num.
-        comparison = a_len - b_len;
+        if (a_len < b_len) {
+            comparison = -1;
+        }
+        else if (a_len > b_len) {
+            comparison = 1;
+        }
 
         // Break ties by doc id.
         if (comparison == 0) {

--- a/core/Lucy/Index/PostingPool.c
+++ b/core/Lucy/Index/PostingPool.c
@@ -523,7 +523,7 @@ PostPool_Refill_IMP(PostingPool *self) {
         // Add to the run's buffer.
         if (num_elems >= ivars->buf_cap) {
             size_t new_cap = Memory_oversize(num_elems + 1, sizeof(Obj*));
-            PostPool_Grow_Buffer(self, new_cap);
+            PostPool_Grow_Buffer(self, (uint32_t)new_cap);
         }
         ivars->buffer[num_elems] = (Obj*)rawpost;
         num_elems++;

--- a/core/Lucy/Index/Similarity.c
+++ b/core/Lucy/Index/Similarity.c
@@ -149,7 +149,7 @@ Sim_TF_IMP(Similarity *self, float freq) {
     return (float)sqrt(freq);
 }
 
-uint32_t
+uint8_t
 Sim_Encode_Norm_IMP(Similarity *self, float f) {
     uint32_t norm;
     UNUSED_VAR(self);
@@ -180,7 +180,7 @@ Sim_Encode_Norm_IMP(Similarity *self, float f) {
         }
     }
 
-    return norm;
+    return (uint8_t)norm;
 }
 
 float

--- a/core/Lucy/Index/Similarity.cfh
+++ b/core/Lucy/Index/Similarity.cfh
@@ -111,7 +111,7 @@ public class Lucy::Index::Similarity nickname Sim inherits Clownfish::Obj {
      * range covered by the single-byte encoding is 7x10^9 to 2x10^-9.  The
      * accuracy is about one significant decimal digit.
      */
-    uint32_t
+    uint8_t
     Encode_Norm(Similarity *self, float f);
 
     /** See encode_norm.

--- a/core/Lucy/Index/SortFieldWriter.c
+++ b/core/Lucy/Index/SortFieldWriter.c
@@ -57,7 +57,7 @@ S_SFWriterElem_create(Obj *value, int32_t doc_id);
 
 static int64_t
 SI_increase_to_word_multiple(int64_t amount) {
-    const int64_t remainder = amount % sizeof(void*);
+    const int64_t remainder = amount % (int64_t)sizeof(void*);
     if (remainder) {
         amount += sizeof(void*);
         amount -= remainder;
@@ -175,7 +175,7 @@ void
 SortFieldWriter_Add_IMP(SortFieldWriter *self, int32_t doc_id, Obj *value) {
     SortFieldWriterIVARS *const ivars = SortFieldWriter_IVARS(self);
     Counter *counter   = ivars->counter;
-    Counter_Add(counter, ivars->mem_per_entry);
+    Counter_Add(counter, (int64_t)ivars->mem_per_entry);
     if (ivars->prim_id == FType_TEXT) {
         int64_t size = (int64_t)Str_Get_Size((String*)value) + 1;
         size = SI_increase_to_word_multiple(size);

--- a/core/Lucy/Index/SortFieldWriter.c
+++ b/core/Lucy/Index/SortFieldWriter.c
@@ -42,7 +42,7 @@
 
 // Prepare to read back a run.
 static void
-S_flip_run(SortFieldWriter *run, size_t sub_thresh, InStream *ord_in,
+S_flip_run(SortFieldWriter *run, uint32_t sub_thresh, InStream *ord_in,
            InStream *ix_in, InStream *dat_in);
 
 // Write out a sort cache.  Returns the number of unique values in the sort
@@ -68,7 +68,7 @@ SI_increase_to_word_multiple(int64_t amount) {
 SortFieldWriter*
 SortFieldWriter_new(Schema *schema, Snapshot *snapshot, Segment *segment,
                     PolyReader *polyreader, String *field,
-                    Counter *counter, size_t mem_thresh,
+                    Counter *counter, uint32_t mem_thresh,
                     OutStream *temp_ord_out, OutStream *temp_ix_out,
                     OutStream *temp_dat_out) {
     SortFieldWriter *self
@@ -82,7 +82,7 @@ SortFieldWriter*
 SortFieldWriter_init(SortFieldWriter *self, Schema *schema,
                      Snapshot *snapshot, Segment *segment,
                      PolyReader *polyreader, String *field,
-                     Counter *counter, size_t mem_thresh,
+                     Counter *counter, uint32_t mem_thresh,
                      OutStream *temp_ord_out, OutStream *temp_ix_out,
                      OutStream *temp_dat_out) {
     // Init.
@@ -518,7 +518,7 @@ SortFieldWriter_Flip_IMP(SortFieldWriter *self) {
         if (!ivars->dat_in) { RETHROW(INCREF(Err_get_error())); }
 
         // Assign streams and a slice of mem_thresh.
-        size_t sub_thresh = ivars->mem_thresh / num_runs;
+        uint32_t sub_thresh = ivars->mem_thresh / num_runs;
         if (sub_thresh < 65536) { sub_thresh = 65536; }
         for (size_t i = 0; i < num_runs; i++) {
             SortFieldWriter *run = (SortFieldWriter*)Vec_Fetch(ivars->runs, i);
@@ -682,7 +682,7 @@ SortFieldWriter_Finish_IMP(SortFieldWriter *self) {
 }
 
 static void
-S_flip_run(SortFieldWriter *run, size_t sub_thresh, InStream *ord_in,
+S_flip_run(SortFieldWriter *run, uint32_t sub_thresh, InStream *ord_in,
            InStream *ix_in, InStream *dat_in) {
     SortFieldWriterIVARS *const run_ivars = SortFieldWriter_IVARS(run);
 

--- a/core/Lucy/Index/SortFieldWriter.cfh
+++ b/core/Lucy/Index/SortFieldWriter.cfh
@@ -54,13 +54,13 @@ class Lucy::Index::SortFieldWriter
     inert incremented SortFieldWriter*
     new(Schema *schema, Snapshot *snapshot, Segment *segment,
         PolyReader *polyreader, String *field, Counter *counter,
-        size_t mem_thresh, OutStream *temp_ord_out, OutStream *temp_ix_out,
+        uint32_t mem_thresh, OutStream *temp_ord_out, OutStream *temp_ix_out,
         OutStream *temp_dat_out);
 
     inert SortFieldWriter*
     init(SortFieldWriter *self, Schema *schema, Snapshot *snapshot,
          Segment *segment, PolyReader *polyreader, String *field,
-         Counter *counter, size_t mem_thresh, OutStream *temp_ord_out,
+         Counter *counter, uint32_t mem_thresh, OutStream *temp_ord_out,
          OutStream *temp_ix_out, OutStream *temp_dat_out);
 
     void

--- a/core/Lucy/Index/SortWriter.c
+++ b/core/Lucy/Index/SortWriter.c
@@ -38,7 +38,7 @@
 
 int32_t SortWriter_current_file_format = 3;
 
-static size_t default_mem_thresh = 0x400000; // 4 MB
+static uint32_t default_mem_thresh = 0x400000; // 4 MB
 
 SortWriter*
 SortWriter_new(Schema *schema, Snapshot *snapshot, Segment *segment,
@@ -84,7 +84,7 @@ SortWriter_Destroy_IMP(SortWriter *self) {
 }
 
 void
-SortWriter_set_default_mem_thresh(size_t mem_thresh) {
+SortWriter_set_default_mem_thresh(uint32_t mem_thresh) {
     default_mem_thresh = mem_thresh;
 }
 

--- a/core/Lucy/Index/SortWriter.cfh
+++ b/core/Lucy/Index/SortWriter.cfh
@@ -36,7 +36,7 @@ class Lucy::Index::SortWriter inherits Lucy::Index::DataWriter {
     OutStream  *temp_ix_out;
     OutStream  *temp_dat_out;
     Counter    *counter;
-    size_t      mem_thresh;
+    uint32_t    mem_thresh;
     bool        flush_at_finish;
 
     inert int32_t current_file_format;
@@ -51,7 +51,7 @@ class Lucy::Index::SortWriter inherits Lucy::Index::DataWriter {
 
     /* Test only. */
     inert void
-    set_default_mem_thresh(size_t mem_thresh);
+    set_default_mem_thresh(uint32_t mem_thresh);
 
     void
     Add_Inverted_Doc(SortWriter *self, Inverter *inverter, int32_t doc_id);

--- a/core/Lucy/Object/BitVector.c
+++ b/core/Lucy/Object/BitVector.c
@@ -265,7 +265,7 @@ S_do_or_or_xor(BitVector *self, const BitVector *other, int operation) {
     uint8_t *bits_a, *bits_b;
     size_t max_cap, min_cap;
     uint8_t *limit;
-    double byte_size;
+    size_t byte_size;
 
     // Sort out what the minimum and maximum caps are.
     if (ivars->cap < ovars->cap) {
@@ -282,7 +282,7 @@ S_do_or_or_xor(BitVector *self, const BitVector *other, int operation) {
     bits_a        = ivars->bits;
     bits_b        = ovars->bits;
     byte_size     = SI_octet_size(min_cap);
-    limit         = ivars->bits + (size_t)byte_size;
+    limit         = ivars->bits + byte_size;
 
     // Perform union of common bits.
     if (operation == DO_OR) {

--- a/core/Lucy/Search/Collector/SortCollector.c
+++ b/core/Lucy/Search/Collector/SortCollector.c
@@ -61,7 +61,7 @@
 #define ACTIONS_MASK                 0x1F
 
 // Pick an action based on a SortRule and if needed, a SortCache.
-static int8_t
+static uint8_t
 S_derive_action(SortRule *rule, SortCache *sort_cache);
 
 // Decide whether a doc should be inserted into the HitQueue.
@@ -178,7 +178,7 @@ SortColl_Destroy_IMP(SortCollector *self) {
     SUPER_DESTROY(self, SORTCOLLECTOR);
 }
 
-static int8_t
+static uint8_t
 S_derive_action(SortRule *rule, SortCache *cache) {
     int32_t  rule_type = SortRule_Get_Type(rule);
     bool reverse   = !!SortRule_Get_Reverse(rule);
@@ -214,7 +214,7 @@ S_derive_action(SortRule *rule, SortCache *cache) {
                 default:
                     ;
             }
-            THROW(ERR, "Unknown width: %i8", width);
+            THROW(ERR, "Unknown width: %i32", width);
         }
         else {
             return AUTO_TIE;
@@ -223,7 +223,7 @@ S_derive_action(SortRule *rule, SortCache *cache) {
     else {
         THROW(ERR, "Unrecognized SortRule type %i32", rule_type);
     }
-    UNREACHABLE_RETURN(int8_t);
+    UNREACHABLE_RETURN(uint8_t);
 }
 
 void

--- a/core/Lucy/Search/IndexSearcher.c
+++ b/core/Lucy/Search/IndexSearcher.c
@@ -115,12 +115,12 @@ TopDocs*
 IxSearcher_Top_Docs_IMP(IndexSearcher *self, Query *query, uint32_t num_wanted,
                         SortSpec *sort_spec) {
     Schema        *schema    = IxSearcher_Get_Schema(self);
-    uint32_t       doc_max   = IxSearcher_Doc_Max(self);
+    uint32_t       doc_max   = (uint32_t)IxSearcher_Doc_Max(self);
     uint32_t       wanted    = num_wanted > doc_max ? doc_max : num_wanted;
     SortCollector *collector = SortColl_new(schema, sort_spec, wanted);
     IxSearcher_Collect(self, query, (Collector*)collector);
     Vector  *match_docs = SortColl_Pop_Match_Docs(collector);
-    int32_t  total_hits = SortColl_Get_Total_Hits(collector);
+    uint32_t total_hits = SortColl_Get_Total_Hits(collector);
     TopDocs *retval     = TopDocs_new(match_docs, total_hits);
     DECREF(collector);
     DECREF(match_docs);

--- a/core/Lucy/Search/PhraseMatcher.c
+++ b/core/Lucy/Search/PhraseMatcher.c
@@ -240,7 +240,7 @@ MATCH:
 
 DONE:
     // Return number of anchors remaining.
-    return anchors_found - anchors_start;
+    return (uint32_t)(anchors_found - anchors_start);
 }
 
 float

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -404,7 +404,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
         I32Array *tv_end_positions   = TV_Get_Positions(last_tv);
         I32Array *tv_start_offsets   = TV_Get_Start_Offsets(first_tv);
         I32Array *tv_end_offsets     = TV_Get_End_Offsets(last_tv);
-        uint32_t  terms_max          = num_terms - 1;
+        int32_t   terms_max          = (int32_t)num_terms - 1;
         I32Array *valid_posits       = BitVec_To_Array(posit_vec);
         size_t    num_valid_posits   = I32Arr_Get_Size(valid_posits);
         size_t j = 0;

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -221,8 +221,8 @@ PhraseCompiler_init(PhraseCompiler *self, PhraseQuery *parent,
     for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         Obj     *term     = Vec_Fetch(terms, i);
         int32_t  doc_max  = Searcher_Doc_Max(searcher);
-        int32_t  doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field, term);
-        ivars->idf += Sim_IDF(sim, doc_freq, doc_max);
+        uint32_t doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field, term);
+        ivars->idf += Sim_IDF(sim, (int32_t)doc_freq, doc_max);
     }
 
     // Calculate raw weight.

--- a/core/Lucy/Search/QueryParser/QueryLexer.c
+++ b/core/Lucy/Search/QueryParser/QueryLexer.c
@@ -36,7 +36,7 @@
 
 static ParserElem*
 S_consume_keyword(StringIterator *iter, const char *keyword,
-                  size_t keyword_len, int type);
+                  size_t keyword_len, uint32_t type);
 
 static ParserElem*
 S_consume_field(StringIterator *iter);
@@ -162,7 +162,7 @@ QueryLexer_Tokenize_IMP(QueryLexer *self, String *query_string) {
 
 static ParserElem*
 S_consume_keyword(StringIterator *iter, const char *keyword,
-                  size_t keyword_len, int type) {
+                  size_t keyword_len, uint32_t type) {
     if (!StrIter_Starts_With_Utf8(iter, keyword, keyword_len)) {
         return NULL;
     }

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -166,10 +166,10 @@ TermCompiler_init(TermCompiler *self, Query *parent, Searcher *searcher,
     ivars->query_norm_factor = 0.0f;
 
     // Derive.
-    int32_t doc_max  = Searcher_Doc_Max(searcher);
-    int32_t doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field,
-                                         parent_ivars->term);
-    ivars->idf = Sim_IDF(sim, doc_freq, doc_max);
+    int32_t  doc_max  = Searcher_Doc_Max(searcher);
+    uint32_t doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field,
+                                          parent_ivars->term);
+    ivars->idf = Sim_IDF(sim, (int32_t)doc_freq, doc_max);
 
     /* The score of any document is approximately equal to:
      *

--- a/core/Lucy/Store/InStream.c
+++ b/core/Lucy/Store/InStream.c
@@ -307,7 +307,7 @@ InStream_Buf_IMP(InStream *self, size_t request) {
      * skip the following refill block. */
     if ((int64_t)request > bytes_in_buf) {
         const int64_t remaining_in_file = ivars->len - SI_tell(self);
-        int64_t amount = request;
+        int64_t amount = (int64_t)request;
 
         // Try to bump up small requests.
         if (amount < IO_STREAM_BUF_SIZE) { amount = IO_STREAM_BUF_SIZE; }

--- a/core/Lucy/Store/InStream.c
+++ b/core/Lucy/Store/InStream.c
@@ -530,7 +530,7 @@ InStream_Read_Raw_C64_IMP(InStream *self, char *buf) {
     do {
         *dest = SI_read_u8(self, ivars);
     } while ((*dest++ & 0x80) != 0);
-    return dest - (uint8_t*)buf;
+    return (int)(dest - (uint8_t*)buf);
 }
 
 

--- a/core/Lucy/Store/Lock.c
+++ b/core/Lucy/Store/Lock.c
@@ -101,7 +101,7 @@ Lock_Obtain_IMP(Lock *self) {
     while (!locked) {
         time_left -= ivars->interval;
         if (time_left <= 0) { break; }
-        Sleep_millisleep(ivars->interval);
+        Sleep_millisleep((uint32_t)ivars->interval);
         locked = Lock_Request(self);
     }
 

--- a/core/Lucy/Store/RAMFileHandle.c
+++ b/core/Lucy/Store/RAMFileHandle.c
@@ -113,7 +113,7 @@ RAMFH_Release_Window_IMP(RAMFileHandle *self, FileWindow *window) {
 bool
 RAMFH_Read_IMP(RAMFileHandle *self, char *dest, int64_t offset, size_t len) {
     RAMFileHandleIVARS *const ivars = RAMFH_IVARS(self);
-    int64_t end = offset + len;
+    int64_t end = offset + (int64_t)len;
     if (!(ivars->flags & FH_READ_ONLY)) {
         Err_set_error(Err_new(Str_newf("Can't read from write-only handle")));
         return false;

--- a/core/Lucy/Util/BlobSortEx.c
+++ b/core/Lucy/Util/BlobSortEx.c
@@ -129,9 +129,8 @@ BlobSortEx_Refill_IMP(BlobSortEx *self) {
         }
 
         if (ivars->buf_max == ivars->buf_cap) {
-            BlobSortEx_Grow_Buffer(self,
-                                 Memory_oversize(ivars->buf_max + 1,
-                                                 sizeof(Obj*)));
+            size_t amount = Memory_oversize(ivars->buf_max + 1, sizeof(Obj*));
+            BlobSortEx_Grow_Buffer(self, (uint32_t)amount);
         }
         ivars->buffer[ivars->buf_max++] = INCREF(elem);
     }

--- a/core/Lucy/Util/SortExternal.c
+++ b/core/Lucy/Util/SortExternal.c
@@ -365,7 +365,7 @@ S_merge(SortExternal *self,
         if (compare(self, left_ptr, right_ptr) <= 0) {
             *dest++ = *left_ptr++;
             if (left_ptr >= left_limit) {
-                right_size = right_limit - right_ptr;
+                right_size = (size_t)(right_limit - right_ptr);
                 memcpy(dest, right_ptr, right_size * sizeof(Obj*));
                 break;
             }
@@ -373,7 +373,7 @@ S_merge(SortExternal *self,
         else {
             *dest++ = *right_ptr++;
             if (right_ptr >= right_limit) {
-                left_size = left_limit - left_ptr;
+                left_size = (size_t)(left_limit - left_ptr);
                 memcpy(dest, left_ptr, left_size * sizeof(Obj*));
                 break;
             }

--- a/core/Lucy/Util/SortExternal.c
+++ b/core/Lucy/Util/SortExternal.c
@@ -98,7 +98,7 @@ SortEx_Feed_IMP(SortExternal *self, Obj *item) {
     SortExternalIVARS *const ivars = SortEx_IVARS(self);
     if (ivars->buf_max == ivars->buf_cap) {
         size_t amount = Memory_oversize(ivars->buf_max + 1, sizeof(Obj*));
-        SortEx_Grow_Buffer(self, amount);
+        SortEx_Grow_Buffer(self, (uint32_t)amount);
     }
     ivars->buffer[ivars->buf_max] = item;
     ivars->buf_max++;
@@ -183,8 +183,8 @@ SortEx_Shrink_IMP(SortExternal *self) {
         }
         ivars->buffer   = (Obj**)REALLOCATE(ivars->buffer, size);
         ivars->buf_tick = 0;
-        ivars->buf_max  = buf_count;
-        ivars->buf_cap  = buf_count;
+        ivars->buf_max  = (uint32_t)buf_count;
+        ivars->buf_cap  = (uint32_t)buf_count;
     }
     else {
         FREEMEM(ivars->buffer);
@@ -293,7 +293,7 @@ S_absorb_slices(SortExternal *self, SortExternalIVARS *ivars,
 
     if (ivars->buf_cap < total_size) {
         size_t cap = Memory_oversize(total_size, sizeof(Obj*));
-        SortEx_Grow_Buffer(self, cap);
+        SortEx_Grow_Buffer(self, (uint32_t)cap);
     }
     ivars->buf_max = total_size;
 
@@ -393,8 +393,8 @@ SortEx_Grow_Buffer_IMP(SortExternal *self, uint32_t cap) {
 static uint32_t
 S_find_slice_size(SortExternal *self, SortExternalIVARS *ivars,
                   Obj **endpost) {
-    int32_t          lo      = ivars->buf_tick - 1;
-    int32_t          hi      = ivars->buf_max;
+    int32_t          lo      = (int32_t)ivars->buf_tick - 1;
+    int32_t          hi      = (int32_t)ivars->buf_max;
     Obj            **buffer  = ivars->buffer;
     SortEx_Compare_t compare
         = METHOD_PTR(SortEx_get_class(self), LUCY_SortEx_Compare);
@@ -408,9 +408,9 @@ S_find_slice_size(SortExternal *self, SortExternalIVARS *ivars,
     }
 
     // If lo is still -1, we didn't find anything.
-    return lo == -1
+    return lo < 0
            ? 0
-           : (lo - ivars->buf_tick) + 1;
+           : ((uint32_t)lo - ivars->buf_tick) + 1;
 }
 
 void

--- a/core/LucyX/Search/ProximityMatcher.c
+++ b/core/LucyX/Search/ProximityMatcher.c
@@ -245,7 +245,7 @@ MATCH:
 
 DONE:
     // Return number of anchors remaining.
-    return anchors_found - anchors_start;
+    return (uint32_t)(anchors_found - anchors_start);
 }
 
 float

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -242,9 +242,9 @@ ProximityCompiler_init(ProximityCompiler *self, ProximityQuery *parent,
     for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         Obj *term = Vec_Fetch(terms, i);
         int32_t doc_max  = Searcher_Doc_Max(searcher);
-        int32_t doc_freq
+        uint32_t doc_freq
             = Searcher_Doc_Freq(searcher, parent_ivars->field,term);
-        ivars->idf += Sim_IDF(sim, doc_freq, doc_max);
+        ivars->idf += Sim_IDF(sim, (int32_t)doc_freq, doc_max);
     }
 
     // Calculate raw weight.

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -433,7 +433,7 @@ ProximityCompiler_Highlight_Spans_IMP(ProximityCompiler *self,
         I32Array *tv_end_positions   = TV_Get_Positions(last_tv);
         I32Array *tv_start_offsets   = TV_Get_Start_Offsets(first_tv);
         I32Array *tv_end_offsets     = TV_Get_End_Offsets(last_tv);
-        uint32_t  terms_max          = num_terms - 1;
+        int32_t   terms_max          = (int32_t)num_terms - 1;
         I32Array *valid_posits       = BitVec_To_Array(posit_vec);
         size_t    num_valid_posits   = I32Arr_Get_Size(valid_posits);
         size_t    j = 0;

--- a/perl/buildlib/Lucy/Build/Binding/Index.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Index.pm
@@ -660,7 +660,7 @@ MODULE = Lucy    PACKAGE = Lucy::Index::PostingListWriter
 
 void
 set_default_mem_thresh(mem_thresh)
-    size_t mem_thresh;
+    uint32_t mem_thresh;
 PPCODE:
     lucy_PListWriter_set_default_mem_thresh(mem_thresh);
 END_XS


### PR DESCRIPTION
Misc int type fixes for -Wconversion, part 2.

*   frequencies (term freq, doc freq)
*   doc counts
*   pointer math results
*   change return type of Sim_Encode_Norm to uint8_t
*   grab bag of other fixes

The only remaining -Wconversion warnings from core/ after this branch gets
merged are in BitVec_Next_Hit, which is arguably buggy.