### PR TITLE
Remove Compiler ivars

### DIFF
--- a/core/Lucy/Docs/Cookbook/CustomQuery.md
+++ b/core/Lucy/Docs/Cookbook/CustomQuery.md
@@ -119,10 +119,7 @@ a subclass of [](cfish:lucy.Compiler).
 ~~~ perl
 sub make_compiler {
     my ( $self, %args ) = @_;
-    my $subordinate = delete $args{subordinate};
-    my $compiler = PrefixCompiler->new( %args, parent => $self );
-    $compiler->normalize unless $subordinate;
-    return $compiler;
+    return PrefixCompiler->new( %args, parent => $self );
 }
 ~~~
 

--- a/core/Lucy/Highlight/Highlighter.c
+++ b/core/Lucy/Highlight/Highlighter.c
@@ -66,9 +66,7 @@ Highlighter_init(Highlighter *self, Searcher *searcher, Obj *query,
         ivars->compiler = (Compiler*)INCREF(ivars->query);
     }
     else {
-        ivars->compiler = Query_Make_Compiler(ivars->query, searcher,
-                                              Query_Get_Boost(ivars->query),
-                                              false);
+        ivars->compiler = Query_Make_Root_Compiler(ivars->query, searcher);
     }
     return self;
 }

--- a/core/Lucy/Highlight/Highlighter.cfh
+++ b/core/Lucy/Highlight/Highlighter.cfh
@@ -26,7 +26,6 @@ parcel Lucy;
 public class Lucy::Highlight::Highlighter inherits Clownfish::Obj {
 
     Searcher   *searcher;
-    Query      *query;
     String     *field;
     uint32_t    excerpt_length;
     uint32_t    slop;
@@ -39,7 +38,7 @@ public class Lucy::Highlight::Highlighter inherits Clownfish::Obj {
      * @param searcher An object which inherits from
      * [](cfish:Searcher), such as an
      * [](cfish:IndexSearcher).
-     * @param query Query object or a query string.
+     * @param query Query object, Compiler object, or a query string.
      * @param field The name of the field from which to draw the excerpt.  The
      * field must marked as be `highlightable` (see
      * [](cfish:FieldType)).
@@ -54,7 +53,7 @@ public class Lucy::Highlight::Highlighter inherits Clownfish::Obj {
      * @param searcher An object which inherits from
      * [](cfish:Searcher), such as an
      * [](cfish:IndexSearcher).
-     * @param query Query object or a query string.
+     * @param query Query object, Compiler object, or a query string.
      * @param field The name of the field from which to draw the excerpt.  The
      * field must marked as be `highlightable` (see
      * [](cfish:FieldType)).
@@ -119,11 +118,6 @@ public class Lucy::Highlight::Highlighter inherits Clownfish::Obj {
      */
     public Searcher*
     Get_Searcher(Highlighter *self);
-
-    /** Accessor.
-     */
-    public Query*
-    Get_Query(Highlighter *self);
 
     /** Accessor for the Lucy::Search::Compiler object derived from
      * `query` and `searcher`.

--- a/core/Lucy/Index/DeletionsWriter.c
+++ b/core/Lucy/Index/DeletionsWriter.c
@@ -280,8 +280,8 @@ DefDelWriter_Delete_By_Term_IMP(DefaultDeletionsWriter *self,
 void
 DefDelWriter_Delete_By_Query_IMP(DefaultDeletionsWriter *self, Query *query) {
     DefaultDeletionsWriterIVARS *const ivars = DefDelWriter_IVARS(self);
-    Compiler *compiler = Query_Make_Compiler(query, (Searcher*)ivars->searcher,
-                                             Query_Get_Boost(query), false);
+    Compiler *compiler
+        = Query_Make_Root_Compiler(query, (Searcher*)ivars->searcher);
 
     for (size_t i = 0, max = Vec_Get_Size(ivars->seg_readers); i < max; i++) {
         SegReader *seg_reader = (SegReader*)Vec_Fetch(ivars->seg_readers, i);

--- a/core/Lucy/Index/Posting.cfh
+++ b/core/Lucy/Index/Posting.cfh
@@ -62,8 +62,7 @@ class Lucy::Index::Posting nickname Post inherits Lucy::Util::Stepper {
     /** Factory method for creating a Matcher.
      */
     abstract incremented Matcher*
-    Make_Matcher(Posting *self, Similarity *sim, PostingList *plist,
-                 float weight, bool need_score);
+    Make_Matcher(Posting *self, PostingList *plist, float weight);
 }
 
 abstract class Lucy::Index::Posting::PostingWriter nickname PostWriter

--- a/core/Lucy/Index/Posting.cfh
+++ b/core/Lucy/Index/Posting.cfh
@@ -63,7 +63,7 @@ class Lucy::Index::Posting nickname Post inherits Lucy::Util::Stepper {
      */
     abstract incremented Matcher*
     Make_Matcher(Posting *self, Similarity *sim, PostingList *plist,
-                 Compiler *compiler, bool need_score);
+                 float weight, bool need_score);
 }
 
 abstract class Lucy::Index::Posting::PostingWriter nickname PostWriter

--- a/core/Lucy/Index/Posting/MatchPosting.c
+++ b/core/Lucy/Index/Posting/MatchPosting.c
@@ -144,21 +144,20 @@ MatchPost_Add_Inversion_To_Pool_IMP(MatchPosting *self,
 
 MatchPostingMatcher*
 MatchPost_Make_Matcher_IMP(MatchPosting *self, Similarity *sim,
-                           PostingList *plist, Compiler *compiler,
-                           bool need_score) {
+                           PostingList *plist, float weight, bool need_score) {
     MatchPostingMatcher *matcher
         = (MatchPostingMatcher*)Class_Make_Obj(MATCHPOSTINGMATCHER);
     UNUSED_VAR(self);
     UNUSED_VAR(need_score);
-    return MatchPostMatcher_init(matcher, sim, plist, compiler);
+    return MatchPostMatcher_init(matcher, sim, plist, weight);
 }
 
 /***************************************************************************/
 
 MatchPostingMatcher*
 MatchPostMatcher_init(MatchPostingMatcher *self, Similarity *sim,
-                      PostingList *plist, Compiler *compiler) {
-    TermMatcher_init((TermMatcher*)self, sim, plist, compiler);
+                      PostingList *plist, float weight) {
+    TermMatcher_init((TermMatcher*)self, sim, plist, weight);
     return self;
 }
 

--- a/core/Lucy/Index/Posting/MatchPosting.c
+++ b/core/Lucy/Index/Posting/MatchPosting.c
@@ -143,21 +143,20 @@ MatchPost_Add_Inversion_To_Pool_IMP(MatchPosting *self,
 }
 
 MatchPostingMatcher*
-MatchPost_Make_Matcher_IMP(MatchPosting *self, Similarity *sim,
-                           PostingList *plist, float weight, bool need_score) {
+MatchPost_Make_Matcher_IMP(MatchPosting *self, PostingList *plist,
+                           float weight) {
     MatchPostingMatcher *matcher
         = (MatchPostingMatcher*)Class_Make_Obj(MATCHPOSTINGMATCHER);
     UNUSED_VAR(self);
-    UNUSED_VAR(need_score);
-    return MatchPostMatcher_init(matcher, sim, plist, weight);
+    return MatchPostMatcher_init(matcher, plist, weight);
 }
 
 /***************************************************************************/
 
 MatchPostingMatcher*
-MatchPostMatcher_init(MatchPostingMatcher *self, Similarity *sim,
-                      PostingList *plist, float weight) {
-    TermMatcher_init((TermMatcher*)self, sim, plist, weight);
+MatchPostMatcher_init(MatchPostingMatcher *self, PostingList *plist,
+                      float weight) {
+    TermMatcher_init((TermMatcher*)self, plist, weight);
     return self;
 }
 

--- a/core/Lucy/Index/Posting/MatchPosting.cfh
+++ b/core/Lucy/Index/Posting/MatchPosting.cfh
@@ -58,16 +58,14 @@ class Lucy::Index::Posting::MatchPosting nickname MatchPost
     Reset(MatchPosting *self);
 
     incremented MatchPostingMatcher*
-    Make_Matcher(MatchPosting *self, Similarity *sim, PostingList *plist,
-                 float weight, bool need_score);
+    Make_Matcher(MatchPosting *self, PostingList *plist, float weight);
 }
 
 class Lucy::Index::Posting::MatchPostingMatcher nickname MatchPostMatcher
     inherits Lucy::Search::TermMatcher {
 
     inert MatchPostingMatcher*
-    init(MatchPostingMatcher *self, Similarity *similarity,
-         PostingList *posting_list, float weight);
+    init(MatchPostingMatcher *self, PostingList *posting_list, float weight);
 
     public float
     Score(MatchPostingMatcher *self);

--- a/core/Lucy/Index/Posting/MatchPosting.cfh
+++ b/core/Lucy/Index/Posting/MatchPosting.cfh
@@ -59,7 +59,7 @@ class Lucy::Index::Posting::MatchPosting nickname MatchPost
 
     incremented MatchPostingMatcher*
     Make_Matcher(MatchPosting *self, Similarity *sim, PostingList *plist,
-                 Compiler *compiler, bool need_score);
+                 float weight, bool need_score);
 }
 
 class Lucy::Index::Posting::MatchPostingMatcher nickname MatchPostMatcher
@@ -67,7 +67,7 @@ class Lucy::Index::Posting::MatchPostingMatcher nickname MatchPostMatcher
 
     inert MatchPostingMatcher*
     init(MatchPostingMatcher *self, Similarity *similarity,
-         PostingList *posting_list, Compiler *compiler);
+         PostingList *posting_list, float weight);
 
     public float
     Score(MatchPostingMatcher *self);

--- a/core/Lucy/Index/Posting/RichPosting.c
+++ b/core/Lucy/Index/Posting/RichPosting.c
@@ -192,20 +192,19 @@ RichPost_Read_Raw_IMP(RichPosting *self, InStream *instream,
 
 RichPostingMatcher*
 RichPost_Make_Matcher_IMP(RichPosting *self, Similarity *sim,
-                          PostingList *plist, Compiler *compiler,
-                          bool need_score) {
+                          PostingList *plist, float weight, bool need_score) {
     RichPostingMatcher* matcher
         = (RichPostingMatcher*)Class_Make_Obj(RICHPOSTINGMATCHER);
     UNUSED_VAR(self);
     UNUSED_VAR(need_score);
-    return RichPostMatcher_init(matcher, sim, plist, compiler);
+    return RichPostMatcher_init(matcher, sim, plist, weight);
 }
 
 RichPostingMatcher*
 RichPostMatcher_init(RichPostingMatcher *self, Similarity *sim,
-                     PostingList *plist, Compiler *compiler) {
+                     PostingList *plist, float weight) {
     return (RichPostingMatcher*)ScorePostMatcher_init((ScorePostingMatcher*)self,
-                                                      sim, plist, compiler);
+                                                      sim, plist, weight);
 }
 
 

--- a/core/Lucy/Index/Posting/RichPosting.c
+++ b/core/Lucy/Index/Posting/RichPosting.c
@@ -191,20 +191,19 @@ RichPost_Read_Raw_IMP(RichPosting *self, InStream *instream,
 }
 
 RichPostingMatcher*
-RichPost_Make_Matcher_IMP(RichPosting *self, Similarity *sim,
-                          PostingList *plist, float weight, bool need_score) {
+RichPost_Make_Matcher_IMP(RichPosting *self, PostingList *plist,
+                          float weight) {
     RichPostingMatcher* matcher
         = (RichPostingMatcher*)Class_Make_Obj(RICHPOSTINGMATCHER);
     UNUSED_VAR(self);
-    UNUSED_VAR(need_score);
-    return RichPostMatcher_init(matcher, sim, plist, weight);
+    return RichPostMatcher_init(matcher, plist, weight);
 }
 
 RichPostingMatcher*
-RichPostMatcher_init(RichPostingMatcher *self, Similarity *sim,
-                     PostingList *plist, float weight) {
+RichPostMatcher_init(RichPostingMatcher *self, PostingList *plist,
+                     float weight) {
     return (RichPostingMatcher*)ScorePostMatcher_init((ScorePostingMatcher*)self,
-                                                      sim, plist, weight);
+                                                      plist, weight);
 }
 
 

--- a/core/Lucy/Index/Posting/RichPosting.cfh
+++ b/core/Lucy/Index/Posting/RichPosting.cfh
@@ -57,7 +57,7 @@ class Lucy::Index::Posting::RichPosting nickname RichPost
 
     incremented RichPostingMatcher*
     Make_Matcher(RichPosting *self, Similarity *sim, PostingList *plist,
-                 Compiler *compiler, bool need_score);
+                 float weight, bool need_score);
 }
 
 class Lucy::Index::Posting::RichPostingMatcher nickname RichPostMatcher
@@ -65,7 +65,7 @@ class Lucy::Index::Posting::RichPostingMatcher nickname RichPostMatcher
 
     inert RichPostingMatcher*
     init(RichPostingMatcher *self, Similarity *similarity,
-         PostingList *posting_list, Compiler *compiler);
+         PostingList *posting_list, float weight);
 }
 
 

--- a/core/Lucy/Index/Posting/RichPosting.cfh
+++ b/core/Lucy/Index/Posting/RichPosting.cfh
@@ -56,16 +56,14 @@ class Lucy::Index::Posting::RichPosting nickname RichPost
                           float length_norm);
 
     incremented RichPostingMatcher*
-    Make_Matcher(RichPosting *self, Similarity *sim, PostingList *plist,
-                 float weight, bool need_score);
+    Make_Matcher(RichPosting *self, PostingList *plist, float weight);
 }
 
 class Lucy::Index::Posting::RichPostingMatcher nickname RichPostMatcher
     inherits Lucy::Index::Posting::ScorePostingMatcher {
 
     inert RichPostingMatcher*
-    init(RichPostingMatcher *self, Similarity *similarity,
-         PostingList *posting_list, float weight);
+    init(RichPostingMatcher *self, PostingList *posting_list, float weight);
 }
 
 

--- a/core/Lucy/Index/Posting/ScorePosting.c
+++ b/core/Lucy/Index/Posting/ScorePosting.c
@@ -212,21 +212,23 @@ ScorePost_Read_Raw_IMP(ScorePosting *self, InStream *instream,
 }
 
 ScorePostingMatcher*
-ScorePost_Make_Matcher_IMP(ScorePosting *self, Similarity *sim,
-                           PostingList *plist, float weight, bool need_score) {
+ScorePost_Make_Matcher_IMP(ScorePosting *self, PostingList *plist,
+                           float weight) {
     ScorePostingMatcher *matcher
         = (ScorePostingMatcher*)Class_Make_Obj(SCOREPOSTINGMATCHER);
     UNUSED_VAR(self);
-    UNUSED_VAR(need_score);
-    return ScorePostMatcher_init(matcher, sim, plist, weight);
+    return ScorePostMatcher_init(matcher, plist, weight);
 }
 
 ScorePostingMatcher*
-ScorePostMatcher_init(ScorePostingMatcher *self, Similarity *sim,
-                      PostingList *plist, float weight) {
+ScorePostMatcher_init(ScorePostingMatcher *self, PostingList *plist,
+                      float weight) {
     // Init.
-    TermMatcher_init((TermMatcher*)self, sim, plist, weight);
+    TermMatcher_init((TermMatcher*)self, (PostingList*)plist, weight);
     ScorePostingMatcherIVARS *const ivars = ScorePostMatcher_IVARS(self);
+
+    Similarity *sim = PList_Get_Similarity(plist);
+    ivars->sim = (Similarity*)INCREF(sim);
 
     // Fill score cache.
     ivars->score_cache = (float*)MALLOCATE(TERMMATCHER_SCORE_CACHE_SIZE * sizeof(float));
@@ -258,6 +260,7 @@ ScorePostMatcher_Score_IMP(ScorePostingMatcher* self) {
 void
 ScorePostMatcher_Destroy_IMP(ScorePostingMatcher *self) {
     ScorePostingMatcherIVARS *const ivars = ScorePostMatcher_IVARS(self);
+    DECREF(ivars->sim);
     FREEMEM(ivars->score_cache);
     SUPER_DESTROY(self, SCOREPOSTINGMATCHER);
 }

--- a/core/Lucy/Index/Posting/ScorePosting.c
+++ b/core/Lucy/Index/Posting/ScorePosting.c
@@ -213,20 +213,19 @@ ScorePost_Read_Raw_IMP(ScorePosting *self, InStream *instream,
 
 ScorePostingMatcher*
 ScorePost_Make_Matcher_IMP(ScorePosting *self, Similarity *sim,
-                           PostingList *plist, Compiler *compiler,
-                           bool need_score) {
+                           PostingList *plist, float weight, bool need_score) {
     ScorePostingMatcher *matcher
         = (ScorePostingMatcher*)Class_Make_Obj(SCOREPOSTINGMATCHER);
     UNUSED_VAR(self);
     UNUSED_VAR(need_score);
-    return ScorePostMatcher_init(matcher, sim, plist, compiler);
+    return ScorePostMatcher_init(matcher, sim, plist, weight);
 }
 
 ScorePostingMatcher*
 ScorePostMatcher_init(ScorePostingMatcher *self, Similarity *sim,
-                      PostingList *plist, Compiler *compiler) {
+                      PostingList *plist, float weight) {
     // Init.
-    TermMatcher_init((TermMatcher*)self, sim, plist, compiler);
+    TermMatcher_init((TermMatcher*)self, sim, plist, weight);
     ScorePostingMatcherIVARS *const ivars = ScorePostMatcher_IVARS(self);
 
     // Fill score cache.

--- a/core/Lucy/Index/Posting/ScorePosting.cfh
+++ b/core/Lucy/Index/Posting/ScorePosting.cfh
@@ -57,7 +57,7 @@ class Lucy::Index::Posting::ScorePosting nickname ScorePost
 
     incremented ScorePostingMatcher*
     Make_Matcher(ScorePosting *self, Similarity *sim, PostingList *plist,
-                 Compiler *compiler, bool need_score);
+                 float weight, bool need_score);
 
     nullable uint32_t*
     Get_Prox(ScorePosting *self);
@@ -70,7 +70,7 @@ class Lucy::Index::Posting::ScorePostingMatcher nickname ScorePostMatcher
 
     inert ScorePostingMatcher*
     init(ScorePostingMatcher *self, Similarity *sim, PostingList *plist,
-         Compiler *compiler);
+         float weight);
 
     public float
     Score(ScorePostingMatcher* self);

--- a/core/Lucy/Index/Posting/ScorePosting.cfh
+++ b/core/Lucy/Index/Posting/ScorePosting.cfh
@@ -56,8 +56,7 @@ class Lucy::Index::Posting::ScorePosting nickname ScorePost
     Reset(ScorePosting *self);
 
     incremented ScorePostingMatcher*
-    Make_Matcher(ScorePosting *self, Similarity *sim, PostingList *plist,
-                 float weight, bool need_score);
+    Make_Matcher(ScorePosting *self, PostingList *plist, float weight);
 
     nullable uint32_t*
     Get_Prox(ScorePosting *self);
@@ -66,11 +65,11 @@ class Lucy::Index::Posting::ScorePosting nickname ScorePost
 class Lucy::Index::Posting::ScorePostingMatcher nickname ScorePostMatcher
     inherits Lucy::Search::TermMatcher {
 
-    float *score_cache;
+    Similarity *sim;
+    float      *score_cache;
 
     inert ScorePostingMatcher*
-    init(ScorePostingMatcher *self, Similarity *sim, PostingList *plist,
-         float weight);
+    init(ScorePostingMatcher *self, PostingList *plist, float weight);
 
     public float
     Score(ScorePostingMatcher* self);

--- a/core/Lucy/Index/PostingList.cfh
+++ b/core/Lucy/Index/PostingList.cfh
@@ -65,7 +65,7 @@ public class Lucy::Index::PostingList nickname PList
     /** Invoke [](cfish:.Post_Make_Matcher) for this PostingList's posting.
      */
     abstract Matcher*
-    Make_Matcher(PostingList *self, float weight, bool need_score);
+    Make_Matcher(PostingList *self, float weight);
 
     /** Indexing helper function.
      */

--- a/core/Lucy/Index/PostingList.cfh
+++ b/core/Lucy/Index/PostingList.cfh
@@ -60,8 +60,8 @@ public class Lucy::Index::PostingList nickname PList
     /** Invoke [](cfish:.Post_Make_Matcher) for this PostingList's posting.
      */
     abstract Matcher*
-    Make_Matcher(PostingList *self, Similarity *similarity,
-                 Compiler *compiler, bool need_score);
+    Make_Matcher(PostingList *self, Similarity *similarity, float weight,
+                 bool need_score);
 
     /** Indexing helper function.
      */

--- a/core/Lucy/Index/PostingList.cfh
+++ b/core/Lucy/Index/PostingList.cfh
@@ -45,6 +45,11 @@ public class Lucy::Index::PostingList nickname PList
     public abstract uint32_t
     Get_Doc_Freq(PostingList *self);
 
+    /** Return the similarity.
+     */
+    abstract Similarity*
+    Get_Similarity(PostingList *self);
+
     /** Prepare the PostingList object to iterate over matches for documents
      * that match `target`.
      *
@@ -60,8 +65,7 @@ public class Lucy::Index::PostingList nickname PList
     /** Invoke [](cfish:.Post_Make_Matcher) for this PostingList's posting.
      */
     abstract Matcher*
-    Make_Matcher(PostingList *self, Similarity *similarity, float weight,
-                 bool need_score);
+    Make_Matcher(PostingList *self, float weight, bool need_score);
 
     /** Indexing helper function.
      */

--- a/core/Lucy/Index/SegPostingList.c
+++ b/core/Lucy/Index/SegPostingList.c
@@ -301,9 +301,10 @@ S_seek_tinfo(SegPostingList *self, TermInfo *tinfo) {
 }
 
 Matcher*
-SegPList_Make_Matcher_IMP(SegPostingList *self, Similarity *sim, float weight,
+SegPList_Make_Matcher_IMP(SegPostingList *self, float weight,
                           bool need_score) {
     SegPostingListIVARS *const ivars = SegPList_IVARS(self);
+    Similarity *sim = SegPList_Get_Similarity(self);
     return Post_Make_Matcher(ivars->posting, sim, (PostingList*)self, weight,
                              need_score);
 }
@@ -316,5 +317,13 @@ SegPList_Read_Raw_IMP(SegPostingList *self, int32_t last_doc_id,
                          last_doc_id, term_text, mem_pool);
 }
 
+Similarity*
+SegPList_Get_Similarity_IMP(SegPostingList *self) {
+    SegPostingListIVARS *const ivars = SegPList_IVARS(self);
+    Schema *schema = PListReader_Get_Schema(ivars->plist_reader);
+    Similarity *sim = Schema_Fetch_Sim(schema, ivars->field);
+    if (!sim) { sim = Schema_Get_Similarity(schema); }
+    return sim;
+}
 
 

--- a/core/Lucy/Index/SegPostingList.c
+++ b/core/Lucy/Index/SegPostingList.c
@@ -301,12 +301,9 @@ S_seek_tinfo(SegPostingList *self, TermInfo *tinfo) {
 }
 
 Matcher*
-SegPList_Make_Matcher_IMP(SegPostingList *self, float weight,
-                          bool need_score) {
+SegPList_Make_Matcher_IMP(SegPostingList *self, float weight) {
     SegPostingListIVARS *const ivars = SegPList_IVARS(self);
-    Similarity *sim = SegPList_Get_Similarity(self);
-    return Post_Make_Matcher(ivars->posting, sim, (PostingList*)self, weight,
-                             need_score);
+    return Post_Make_Matcher(ivars->posting, (PostingList*)self, weight);
 }
 
 RawPosting*

--- a/core/Lucy/Index/SegPostingList.c
+++ b/core/Lucy/Index/SegPostingList.c
@@ -301,10 +301,10 @@ S_seek_tinfo(SegPostingList *self, TermInfo *tinfo) {
 }
 
 Matcher*
-SegPList_Make_Matcher_IMP(SegPostingList *self, Similarity *sim,
-                          Compiler *compiler, bool need_score) {
+SegPList_Make_Matcher_IMP(SegPostingList *self, Similarity *sim, float weight,
+                          bool need_score) {
     SegPostingListIVARS *const ivars = SegPList_IVARS(self);
-    return Post_Make_Matcher(ivars->posting, sim, (PostingList*)self, compiler,
+    return Post_Make_Matcher(ivars->posting, sim, (PostingList*)self, weight,
                              need_score);
 }
 

--- a/core/Lucy/Index/SegPostingList.cfh
+++ b/core/Lucy/Index/SegPostingList.cfh
@@ -75,8 +75,8 @@ class Lucy::Index::SegPostingList nickname SegPList
     Seek_Lex(SegPostingList *self, Lexicon *lexicon);
 
     Matcher*
-    Make_Matcher(SegPostingList *self, Similarity *similarity,
-                 Compiler *compiler, bool need_score);
+    Make_Matcher(SegPostingList *self, Similarity *similarity, float weight,
+                 bool need_score);
 
     RawPosting*
     Read_Raw(SegPostingList *self, int32_t last_doc_id, String *term_text,

--- a/core/Lucy/Index/SegPostingList.cfh
+++ b/core/Lucy/Index/SegPostingList.cfh
@@ -78,7 +78,7 @@ class Lucy::Index::SegPostingList nickname SegPList
     Seek_Lex(SegPostingList *self, Lexicon *lexicon);
 
     Matcher*
-    Make_Matcher(SegPostingList *self, float weight, bool need_score);
+    Make_Matcher(SegPostingList *self, float weight);
 
     RawPosting*
     Read_Raw(SegPostingList *self, int32_t last_doc_id, String *term_text,

--- a/core/Lucy/Index/SegPostingList.cfh
+++ b/core/Lucy/Index/SegPostingList.cfh
@@ -60,6 +60,9 @@ class Lucy::Index::SegPostingList nickname SegPList
     Posting*
     Get_Posting(SegPostingList *self);
 
+    Similarity*
+    Get_Similarity(SegPostingList *self);
+
     public int32_t
     Next(SegPostingList *self);
 
@@ -75,8 +78,7 @@ class Lucy::Index::SegPostingList nickname SegPList
     Seek_Lex(SegPostingList *self, Lexicon *lexicon);
 
     Matcher*
-    Make_Matcher(SegPostingList *self, Similarity *similarity, float weight,
-                 bool need_score);
+    Make_Matcher(SegPostingList *self, float weight, bool need_score);
 
     RawPosting*
     Read_Raw(SegPostingList *self, int32_t last_doc_id, String *term_text,

--- a/core/Lucy/Search/ANDQuery.c
+++ b/core/Lucy/Search/ANDQuery.c
@@ -79,13 +79,8 @@ ANDQuery_Equals_IMP(ANDQuery *self, Obj *other) {
 }
 
 Compiler*
-ANDQuery_Make_Compiler_IMP(ANDQuery *self, Searcher *searcher, float boost,
-                           bool subordinate) {
-    ANDCompiler *compiler = ANDCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        ANDCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+ANDQuery_Make_Compiler_IMP(ANDQuery *self, Searcher *searcher, float boost) {
+    return (Compiler*)ANDCompiler_new(self, searcher, boost);
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/ANDQuery.c
+++ b/core/Lucy/Search/ANDQuery.c
@@ -86,17 +86,26 @@ ANDQuery_Make_Compiler_IMP(ANDQuery *self, Searcher *searcher, float boost) {
 /**********************************************************************/
 
 ANDCompiler*
-ANDCompiler_new(ANDQuery *parent, Searcher *searcher, float boost) {
+ANDCompiler_new(ANDQuery *query, Searcher *searcher, float boost) {
     ANDCompiler *self = (ANDCompiler*)Class_Make_Obj(ANDCOMPILER);
-    return ANDCompiler_init(self, parent, searcher, boost);
+    return ANDCompiler_init(self, query, searcher, boost);
 }
 
 ANDCompiler*
-ANDCompiler_init(ANDCompiler *self, ANDQuery *parent, Searcher *searcher,
+ANDCompiler_init(ANDCompiler *self, ANDQuery *query, Searcher *searcher,
                  float boost) {
-    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)parent, searcher,
-                      boost);
+    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)query, searcher, boost);
     return self;
+}
+
+bool
+ANDCompiler_Equals_IMP(ANDCompiler *self, Obj *other) {
+    if ((ANDCompiler*)other == self)   { return true;  }
+    if (!Obj_is_a(other, ANDCOMPILER)) { return false; }
+    ANDCompiler_Equals_t super_equals
+        = (ANDCompiler_Equals_t)SUPER_METHOD_PTR(ANDCOMPILER,
+                                                 LUCY_ANDCompiler_Equals);
+    return super_equals(self, other);
 }
 
 Matcher*
@@ -128,9 +137,9 @@ ANDCompiler_Make_Matcher_IMP(ANDCompiler *self, SegReader *reader,
             }
         }
 
-        Matcher *retval
-            = (Matcher*)ANDMatcher_new(child_matchers,
-                                       ANDCompiler_Get_Similarity(self));
+        Schema *schema = SegReader_Get_Schema(reader);
+        Similarity *sim = Schema_Get_Similarity(schema);
+        Matcher *retval = (Matcher*)ANDMatcher_new(child_matchers, sim);
         DECREF(child_matchers);
         return retval;
 

--- a/core/Lucy/Search/ANDQuery.cfh
+++ b/core/Lucy/Search/ANDQuery.cfh
@@ -52,14 +52,17 @@ class Lucy::Search::ANDCompiler
     inherits Lucy::Search::PolyCompiler {
 
     inert incremented ANDCompiler*
-    new(ANDQuery *parent, Searcher *searcher, float boost);
+    new(ANDQuery *query, Searcher *searcher, float boost);
 
     inert ANDCompiler*
-    init(ANDCompiler *self, ANDQuery *parent, Searcher *searcher,
+    init(ANDCompiler *self, ANDQuery *query, Searcher *searcher,
          float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(ANDCompiler *self, SegReader *reader, bool need_score);
+
+    public bool
+    Equals(ANDCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/ANDQuery.cfh
+++ b/core/Lucy/Search/ANDQuery.cfh
@@ -39,8 +39,7 @@ public class Lucy::Search::ANDQuery inherits Lucy::Search::PolyQuery {
     init(ANDQuery *self, Vector *children = NULL);
 
     public incremented Compiler*
-    Make_Compiler(ANDQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(ANDQuery *self, Searcher *searcher, float boost);
 
     public incremented String*
     To_String(ANDQuery *self);

--- a/core/Lucy/Search/Compiler.cfh
+++ b/core/Lucy/Search/Compiler.cfh
@@ -30,7 +30,7 @@ parcel Lucy;
  * However it is common for the Compiler to perform some calculations which
  * affect it's "weight" -- a floating point multiplier that the Matcher will
  * factor into each document's score.  If that is the case, then the Compiler
- * subclass may wish to override [](cfish:.Get_Weight), [](cfish:.Sum_Of_Squared_Weights), and
+ * subclass may wish to override [](cfish:.Sum_Of_Squared_Weights) and
  * [](cfish:.Apply_Norm_Factor).
  *
  * Compiling a Matcher is a two stage process.
@@ -57,23 +57,12 @@ parcel Lucy;
  * the Matchers's constructor, or whether [](cfish:.Make_Matcher) should return a
  * Matcher at all.
  */
-public class Lucy::Search::Compiler inherits Lucy::Search::Query {
-
-    Query        *parent;
-    Similarity   *sim;
+public class Lucy::Search::Compiler {
 
     /** Abstract initializer.
-     *
-     * @param parent The parent Query.
-     * @param searcher A Lucy::Search::Searcher, such as an
-     * IndexSearcher.
-     * @param similarity A Similarity.
-     * @param boost An arbitrary scoring multiplier.  Defaults to the boost of
-     * the parent Query.
      */
     public inert Compiler*
-    init(Compiler *self, Query *parent, Searcher *searcher,
-         Similarity *similarity = NULL, float boost);
+    init(Compiler *self);
 
     /** Factory method returning a Matcher.
      *
@@ -84,22 +73,6 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
      */
     public abstract incremented nullable Matcher*
     Make_Matcher(Compiler *self, SegReader *reader, bool need_score);
-
-    /** Return the Compiler's numerical weight, a scoring multiplier.  By
-     * default, returns the object's boost.
-     */
-    public float
-    Get_Weight(Compiler *self);
-
-    /** Accessor for the Compiler's Similarity object.
-     */
-    public nullable Similarity*
-    Get_Similarity(Compiler *self);
-
-    /** Accessor for the Compiler's parent Query object.
-     */
-    public Query*
-    Get_Parent(Compiler *self);
 
     /** Compute and return a raw weighting factor.  (This quantity is used by
      * [](cfish:.Normalize)).  By default, simply returns 1.0.
@@ -133,10 +106,10 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
      * implemented.
      */
     public void
-    Normalize(Compiler *self);
+    Normalize(Compiler *self, Similarity *sim);
 
     /** Return an array of Span objects, indicating where in the given field
-     * the text that matches the parent Query occurs and how well each snippet
+     * the text that matches the Query occurs and how well each snippet
      * matches.  The Span's offset and length are measured in Unicode code
      * points.
      *
@@ -150,20 +123,11 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
     Highlight_Spans(Compiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
 
-    void
+    abstract void
     Serialize(Compiler *self, OutStream *outstream);
 
-    incremented Compiler*
+    abstract incremented Compiler*
     Deserialize(decremented Compiler *self, InStream *instream);
-
-    public bool
-    Equals(Compiler *self, Obj *other);
-
-    public incremented String*
-    To_String(Compiler *self);
-
-    public void
-    Destroy(Compiler *self);
 }
 
 

--- a/core/Lucy/Search/Compiler.cfh
+++ b/core/Lucy/Search/Compiler.cfh
@@ -121,8 +121,7 @@ public class Lucy::Search::Compiler inherits Lucy::Search::Query {
     Apply_Norm_Factor(Compiler *self, float factor);
 
     /**  Take a newly minted Compiler object and apply query-specific
-     * normalization factors.  Should be invoked by Query subclasses during
-     * [](cfish:.Make_Compiler) for top-level nodes.
+     * normalization factors.
      *
      * For a TermQuery, the scoring formula is approximately:
      *

--- a/core/Lucy/Search/IndexSearcher.c
+++ b/core/Lucy/Search/IndexSearcher.c
@@ -135,8 +135,7 @@ IxSearcher_Collect_IMP(IndexSearcher *self, Query *query, Collector *collector) 
     bool      need_score        = Coll_Need_Score(collector);
     Compiler *compiler = Query_is_a(query, COMPILER)
                          ? (Compiler*)INCREF(query)
-                         : Query_Make_Compiler(query, (Searcher*)self,
-                                               Query_Get_Boost(query), false);
+                         : Query_Make_Root_Compiler(query, (Searcher*)self);
 
     // Accumulate hits into the Collector.
     for (size_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {

--- a/core/Lucy/Search/IndexSearcher.c
+++ b/core/Lucy/Search/IndexSearcher.c
@@ -112,7 +112,7 @@ IxSearcher_Doc_Freq_IMP(IndexSearcher *self, String *field, Obj *term) {
 }
 
 TopDocs*
-IxSearcher_Top_Docs_IMP(IndexSearcher *self, Query *query, uint32_t num_wanted,
+IxSearcher_Top_Docs_IMP(IndexSearcher *self, Obj *query, uint32_t num_wanted,
                         SortSpec *sort_spec) {
     Schema        *schema    = IxSearcher_Get_Schema(self);
     uint32_t       doc_max   = (uint32_t)IxSearcher_Doc_Max(self);
@@ -128,14 +128,23 @@ IxSearcher_Top_Docs_IMP(IndexSearcher *self, Query *query, uint32_t num_wanted,
 }
 
 void
-IxSearcher_Collect_IMP(IndexSearcher *self, Query *query, Collector *collector) {
+IxSearcher_Collect_IMP(IndexSearcher *self, Obj *query, Collector *collector) {
     IndexSearcherIVARS *const ivars = IxSearcher_IVARS(self);
     Vector   *const seg_readers = ivars->seg_readers;
     I32Array *const seg_starts  = ivars->seg_starts;
     bool      need_score        = Coll_Need_Score(collector);
-    Compiler *compiler = Query_is_a(query, COMPILER)
-                         ? (Compiler*)INCREF(query)
-                         : Query_Make_Root_Compiler(query, (Searcher*)self);
+    Compiler *compiler;
+
+    if (Obj_is_a(query, QUERY)) {
+        compiler = Query_Make_Root_Compiler((Query*)query, (Searcher*)self);
+    }
+    else if (Obj_is_a(query, COMPILER)) {
+        compiler = (Compiler*)INCREF(query);
+    }
+    else {
+        THROW(ERR, "Invalid query type: %o", Obj_get_class_name(query));
+        return;
+    }
 
     // Accumulate hits into the Collector.
     for (size_t i = 0, max = Vec_Get_Size(seg_readers); i < max; i++) {

--- a/core/Lucy/Search/IndexSearcher.cfh
+++ b/core/Lucy/Search/IndexSearcher.cfh
@@ -59,10 +59,10 @@ public class Lucy::Search::IndexSearcher nickname IxSearcher
     Doc_Freq(IndexSearcher *self, String *field, Obj *term);
 
     public void
-    Collect(IndexSearcher *self, Query *query, Collector *collector);
+    Collect(IndexSearcher *self, Obj *query, Collector *collector);
 
     incremented TopDocs*
-    Top_Docs(IndexSearcher *self, Query *query, uint32_t num_wanted,
+    Top_Docs(IndexSearcher *self, Obj *query, uint32_t num_wanted,
              SortSpec *sort_spec = NULL);
 
     public incremented HitDoc*

--- a/core/Lucy/Search/LeafQuery.c
+++ b/core/Lucy/Search/LeafQuery.c
@@ -142,12 +142,10 @@ LeafQuery_Load_IMP(LeafQuery *self, Obj *dump) {
 }
 
 Compiler*
-LeafQuery_Make_Compiler_IMP(LeafQuery *self, Searcher *searcher, float boost,
-                            bool subordinate) {
+LeafQuery_Make_Compiler_IMP(LeafQuery *self, Searcher *searcher, float boost) {
     UNUSED_VAR(self);
     UNUSED_VAR(searcher);
     UNUSED_VAR(boost);
-    UNUSED_VAR(subordinate);
     THROW(ERR, "Can't Make_Compiler() from LeafQuery");
     UNREACHABLE_RETURN(Compiler*);
 }

--- a/core/Lucy/Search/LeafQuery.cfh
+++ b/core/Lucy/Search/LeafQuery.cfh
@@ -77,8 +77,7 @@ public class Lucy::Search::LeafQuery inherits Lucy::Search::Query {
     /** Throws an error.
      */
     public incremented Compiler*
-    Make_Compiler(LeafQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(LeafQuery *self, Searcher *searcher, float boost);
 
     public void
     Destroy(LeafQuery *self);

--- a/core/Lucy/Search/MatchAllQuery.c
+++ b/core/Lucy/Search/MatchAllQuery.c
@@ -57,12 +57,8 @@ MatchAllQuery_To_String_IMP(MatchAllQuery *self) {
 
 Compiler*
 MatchAllQuery_Make_Compiler_IMP(MatchAllQuery *self, Searcher *searcher,
-                                float boost, bool subordinate) {
-    MatchAllCompiler *compiler = MatchAllCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        MatchAllCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+                                float boost) {
+    return (Compiler*)MatchAllCompiler_new(self, searcher, boost);
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/MatchAllQuery.cfh
+++ b/core/Lucy/Search/MatchAllQuery.cfh
@@ -42,8 +42,7 @@ public class Lucy::Search::MatchAllQuery inherits Lucy::Search::Query {
     To_String(MatchAllQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(MatchAllQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(MatchAllQuery *self, Searcher *searcher, float boost);
 }
 
 class Lucy::Search::MatchAllCompiler

--- a/core/Lucy/Search/MatchAllQuery.cfh
+++ b/core/Lucy/Search/MatchAllQuery.cfh
@@ -48,16 +48,26 @@ public class Lucy::Search::MatchAllQuery inherits Lucy::Search::Query {
 class Lucy::Search::MatchAllCompiler
     inherits Lucy::Search::Compiler {
 
+    float boost;
+
     inert incremented MatchAllCompiler*
-    new(MatchAllQuery *parent, Searcher *searcher, float boost);
+    new(float boost);
 
     inert MatchAllCompiler*
-    init(MatchAllCompiler *self, MatchAllQuery *parent,
-         Searcher *searcher, float boost);
+    init(MatchAllCompiler *self, float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(MatchAllCompiler *self, SegReader *reader,
                  bool need_score);
+
+    void
+    Serialize(MatchAllCompiler *self, OutStream *outstream);
+
+    incremented MatchAllCompiler*
+    Deserialize(decremented MatchAllCompiler *self, InStream *instream);
+
+    public bool
+    Equals(MatchAllCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/NOTQuery.c
+++ b/core/Lucy/Search/NOTQuery.c
@@ -72,13 +72,8 @@ NOTQuery_Equals_IMP(NOTQuery *self, Obj *other) {
 }
 
 Compiler*
-NOTQuery_Make_Compiler_IMP(NOTQuery *self, Searcher *searcher, float boost,
-                           bool subordinate) {
-    NOTCompiler *compiler = NOTCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        NOTCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+NOTQuery_Make_Compiler_IMP(NOTQuery *self, Searcher *searcher, float boost) {
+    return (Compiler*)NOTCompiler_new(self, searcher, boost);
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/NOTQuery.c
+++ b/core/Lucy/Search/NOTQuery.c
@@ -21,6 +21,8 @@
 #include "Lucy/Search/NOTQuery.h"
 #include "Lucy/Index/DocVector.h"
 #include "Lucy/Index/SegReader.h"
+#include "Lucy/Index/Similarity.h"
+#include "Lucy/Plan/Schema.h"
 #include "Lucy/Search/MatchAllMatcher.h"
 #include "Lucy/Search/NOTMatcher.h"
 #include "Lucy/Search/Searcher.h"
@@ -79,17 +81,27 @@ NOTQuery_Make_Compiler_IMP(NOTQuery *self, Searcher *searcher, float boost) {
 /**********************************************************************/
 
 NOTCompiler*
-NOTCompiler_new(NOTQuery *parent, Searcher *searcher, float boost) {
+NOTCompiler_new(NOTQuery *query, Searcher *searcher, float boost) {
     NOTCompiler *self = (NOTCompiler*)Class_Make_Obj(NOTCOMPILER);
-    return NOTCompiler_init(self, parent, searcher, boost);
+    return NOTCompiler_init(self, query, searcher, boost);
 }
 
 NOTCompiler*
-NOTCompiler_init(NOTCompiler *self, NOTQuery *parent, Searcher *searcher,
+NOTCompiler_init(NOTCompiler *self, NOTQuery *query, Searcher *searcher,
                  float boost) {
-    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)parent, searcher,
+    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)query, searcher,
                       boost);
     return self;
+}
+
+bool
+NOTCompiler_Equals_IMP(NOTCompiler *self, Obj *other) {
+    if ((NOTCompiler*)other == self)   { return true;  }
+    if (!Obj_is_a(other, NOTCOMPILER)) { return false; }
+    NOTCompiler_Equals_t super_equals
+        = (NOTCompiler_Equals_t)SUPER_METHOD_PTR(NOTCOMPILER,
+                                                 LUCY_NOTCompiler_Equals);
+    return super_equals(self, other);
 }
 
 float
@@ -119,7 +131,7 @@ NOTCompiler_Make_Matcher_IMP(NOTCompiler *self, SegReader *reader,
     UNUSED_VAR(need_score);
 
     if (negated_matcher == NULL) {
-        float weight = NOTCompiler_Get_Weight(self);
+        float weight = ivars->boost;
         int32_t doc_max = SegReader_Doc_Max(reader);
         return (Matcher*)MatchAllMatcher_new(weight, doc_max);
     }

--- a/core/Lucy/Search/NOTQuery.cfh
+++ b/core/Lucy/Search/NOTQuery.cfh
@@ -65,10 +65,10 @@ class Lucy::Search::NOTCompiler
     inherits Lucy::Search::PolyCompiler {
 
     inert incremented NOTCompiler*
-    new(NOTQuery *parent, Searcher *searcher, float boost);
+    new(NOTQuery *query, Searcher *searcher, float boost);
 
     inert NOTCompiler*
-    init(NOTCompiler *self, NOTQuery *parent, Searcher *searcher,
+    init(NOTCompiler *self, NOTQuery *query, Searcher *searcher,
          float boost);
 
     public incremented nullable Matcher*
@@ -80,6 +80,9 @@ class Lucy::Search::NOTCompiler
     incremented Vector*
     Highlight_Spans(NOTCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
+
+    public bool
+    Equals(NOTCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/NOTQuery.cfh
+++ b/core/Lucy/Search/NOTQuery.cfh
@@ -52,8 +52,7 @@ public class Lucy::Search::NOTQuery inherits Lucy::Search::PolyQuery {
     Set_Negated_Query(NOTQuery *self, Query *negated_query);
 
     public incremented Compiler*
-    Make_Compiler(NOTQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(NOTQuery *self, Searcher *searcher, float boost);
 
     public incremented String*
     To_String(NOTQuery *self);

--- a/core/Lucy/Search/NoMatchQuery.c
+++ b/core/Lucy/Search/NoMatchQuery.c
@@ -62,7 +62,10 @@ NoMatchQuery_To_String_IMP(NoMatchQuery *self) {
 Compiler*
 NoMatchQuery_Make_Compiler_IMP(NoMatchQuery *self, Searcher *searcher,
                                float boost) {
-    return (Compiler*)NoMatchCompiler_new(self, searcher, boost);
+    UNUSED_VAR(self);
+    UNUSED_VAR(searcher);
+    UNUSED_VAR(boost);
+    return (Compiler*)NoMatchCompiler_new();
 }
 
 void
@@ -114,18 +117,35 @@ NoMatchQuery_Deserialize_IMP(NoMatchQuery *self, InStream *instream) {
 /**********************************************************************/
 
 NoMatchCompiler*
-NoMatchCompiler_new(NoMatchQuery *parent, Searcher *searcher,
-                    float boost) {
+NoMatchCompiler_new() {
     NoMatchCompiler *self
         = (NoMatchCompiler*)Class_Make_Obj(NOMATCHCOMPILER);
-    return NoMatchCompiler_init(self, parent, searcher, boost);
+    return NoMatchCompiler_init(self);
+}
+
+bool
+NoMatchCompiler_Equals_IMP(NoMatchCompiler *self, Obj *other) {
+    if ((NoMatchCompiler*)other == self)   { return true; }
+    if (!Obj_is_a(other, NOMATCHCOMPILER)) { return false; }
+    return true;
+}
+
+// Perl's Storable doesn't cope with empty strings.
+void
+NoMatchCompiler_Serialize_IMP(NoMatchCompiler *self, OutStream *outstream) {
+    UNUSED_VAR(self);
+    OutStream_Write_I8(outstream, 'x');
 }
 
 NoMatchCompiler*
-NoMatchCompiler_init(NoMatchCompiler *self, NoMatchQuery *parent,
-                     Searcher *searcher, float boost) {
-    return (NoMatchCompiler*)Compiler_init((Compiler*)self, (Query*)parent,
-                                           searcher, NULL, boost);
+NoMatchCompiler_Deserialize_IMP(NoMatchCompiler *self, InStream *instream) {
+    InStream_Read_I8(instream);
+    return self;
+}
+
+NoMatchCompiler*
+NoMatchCompiler_init(NoMatchCompiler *self) {
+    return (NoMatchCompiler*)Compiler_init((Compiler*)self);
 }
 
 Matcher*

--- a/core/Lucy/Search/NoMatchQuery.c
+++ b/core/Lucy/Search/NoMatchQuery.c
@@ -61,12 +61,8 @@ NoMatchQuery_To_String_IMP(NoMatchQuery *self) {
 
 Compiler*
 NoMatchQuery_Make_Compiler_IMP(NoMatchQuery *self, Searcher *searcher,
-                               float boost, bool subordinate) {
-    NoMatchCompiler *compiler = NoMatchCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        NoMatchCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+                               float boost) {
+    return (Compiler*)NoMatchCompiler_new(self, searcher, boost);
 }
 
 void

--- a/core/Lucy/Search/NoMatchQuery.cfh
+++ b/core/Lucy/Search/NoMatchQuery.cfh
@@ -69,14 +69,22 @@ class Lucy::Search::NoMatchCompiler
     inherits Lucy::Search::Compiler {
 
     inert incremented NoMatchCompiler*
-    new(NoMatchQuery *parent, Searcher *searcher, float boost);
+    new();
 
     inert NoMatchCompiler*
-    init(NoMatchCompiler *self, NoMatchQuery *parent,
-         Searcher *searcher, float boost);
+    init(NoMatchCompiler *self);
 
     public incremented nullable Matcher*
     Make_Matcher(NoMatchCompiler *self, SegReader *reader, bool need_score);
+
+    void
+    Serialize(NoMatchCompiler *self, OutStream *outstream);
+
+    incremented NoMatchCompiler*
+    Deserialize(decremented NoMatchCompiler *self, InStream *instream);
+
+    public bool
+    Equals(NoMatchCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/NoMatchQuery.cfh
+++ b/core/Lucy/Search/NoMatchQuery.cfh
@@ -62,8 +62,7 @@ public class Lucy::Search::NoMatchQuery inherits Lucy::Search::Query {
     To_String(NoMatchQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(NoMatchQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(NoMatchQuery *self, Searcher *searcher, float boost);
 }
 
 class Lucy::Search::NoMatchCompiler

--- a/core/Lucy/Search/ORQuery.c
+++ b/core/Lucy/Search/ORQuery.c
@@ -23,6 +23,7 @@
 #include "Clownfish/CharBuf.h"
 #include "Lucy/Index/SegReader.h"
 #include "Lucy/Index/Similarity.h"
+#include "Lucy/Plan/Schema.h"
 #include "Lucy/Search/ORMatcher.h"
 #include "Lucy/Search/Searcher.h"
 #include "Lucy/Store/InStream.h"
@@ -82,17 +83,26 @@ ORQuery_To_String_IMP(ORQuery *self) {
 /**********************************************************************/
 
 ORCompiler*
-ORCompiler_new(ORQuery *parent, Searcher *searcher, float boost) {
+ORCompiler_new(ORQuery *query, Searcher *searcher, float boost) {
     ORCompiler *self = (ORCompiler*)Class_Make_Obj(ORCOMPILER);
-    return ORCompiler_init(self, parent, searcher, boost);
+    return ORCompiler_init(self, query, searcher, boost);
 }
 
 ORCompiler*
-ORCompiler_init(ORCompiler *self, ORQuery *parent, Searcher *searcher,
+ORCompiler_init(ORCompiler *self, ORQuery *query, Searcher *searcher,
                 float boost) {
-    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)parent, searcher,
-                      boost);
+    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)query, searcher, boost);
     return self;
+}
+
+bool
+ORCompiler_Equals_IMP(ORCompiler *self, Obj *other) {
+    if ((ORCompiler*)other == self)   { return true;  }
+    if (!Obj_is_a(other, ORCOMPILER)) { return false; }
+    ORCompiler_Equals_t super_equals
+        = (ORCompiler_Equals_t)SUPER_METHOD_PTR(ORCOMPILER,
+                                                LUCY_ORCompiler_Equals);
+    return super_equals(self, other);
 }
 
 Matcher*
@@ -127,10 +137,11 @@ ORCompiler_Make_Matcher_IMP(ORCompiler *self, SegReader *reader,
             return NULL;
         }
         else {
-            Similarity *sim    = ORCompiler_Get_Similarity(self);
-            Matcher    *retval = need_score
-                                 ? (Matcher*)ORScorer_new(submatchers, sim)
-                                 : (Matcher*)ORMatcher_new(submatchers);
+            Schema *schema = SegReader_Get_Schema(reader);
+            Similarity *sim = Schema_Get_Similarity(schema);
+            Matcher *retval = need_score
+                              ? (Matcher*)ORScorer_new(submatchers, sim)
+                              : (Matcher*)ORMatcher_new(submatchers);
             DECREF(submatchers);
             return retval;
         }

--- a/core/Lucy/Search/ORQuery.c
+++ b/core/Lucy/Search/ORQuery.c
@@ -40,13 +40,8 @@ ORQuery_init(ORQuery *self, Vector *children) {
 }
 
 Compiler*
-ORQuery_Make_Compiler_IMP(ORQuery *self, Searcher *searcher, float boost,
-                          bool subordinate) {
-    ORCompiler *compiler = ORCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        ORCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+ORQuery_Make_Compiler_IMP(ORQuery *self, Searcher *searcher, float boost) {
+    return (Compiler*)ORCompiler_new(self, searcher, boost);
 }
 
 bool

--- a/core/Lucy/Search/ORQuery.cfh
+++ b/core/Lucy/Search/ORQuery.cfh
@@ -54,14 +54,17 @@ class Lucy::Search::ORCompiler
     inherits Lucy::Search::PolyCompiler {
 
     inert incremented ORCompiler*
-    new(ORQuery *parent, Searcher *searcher, float boost);
+    new(ORQuery *query, Searcher *searcher, float boost);
 
     inert ORCompiler*
-    init(ORCompiler *self, ORQuery *parent, Searcher *searcher,
+    init(ORCompiler *self, ORQuery *query, Searcher *searcher,
          float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(ORCompiler *self, SegReader *reader, bool need_score);
+
+    public bool
+    Equals(ORCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/ORQuery.cfh
+++ b/core/Lucy/Search/ORQuery.cfh
@@ -41,8 +41,7 @@ public class Lucy::Search::ORQuery inherits Lucy::Search::PolyQuery {
     init(ORQuery *self, Vector *children = NULL);
 
     public incremented Compiler*
-    Make_Compiler(ORQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(ORQuery *self, Searcher *searcher, float boost);
 
     public incremented String*
     To_String(ORQuery *self);

--- a/core/Lucy/Search/PhraseMatcher.c
+++ b/core/Lucy/Search/PhraseMatcher.c
@@ -26,15 +26,15 @@
 #include "Lucy/Search/Compiler.h"
 
 PhraseMatcher*
-PhraseMatcher_new(Similarity *sim, Vector *plists, Compiler *compiler) {
+PhraseMatcher_new(Similarity *sim, Vector *plists, float weight) {
     PhraseMatcher *self = (PhraseMatcher*)Class_Make_Obj(PHRASEMATCHER);
-    return PhraseMatcher_init(self, sim, plists, compiler);
+    return PhraseMatcher_init(self, sim, plists, weight);
 
 }
 
 PhraseMatcher*
 PhraseMatcher_init(PhraseMatcher *self, Similarity *similarity, Vector *plists,
-                   Compiler *compiler) {
+                   float weight) {
     Matcher_init((Matcher*)self);
     PhraseMatcherIVARS *const ivars = PhraseMatcher_IVARS(self);
 
@@ -59,9 +59,8 @@ PhraseMatcher_init(PhraseMatcher *self, Similarity *similarity, Vector *plists,
     }
 
     // Assign.
-    ivars->sim       = (Similarity*)INCREF(similarity);
-    ivars->compiler  = (Compiler*)INCREF(compiler);
-    ivars->weight    = Compiler_Get_Weight(compiler);
+    ivars->sim    = (Similarity*)INCREF(similarity);
+    ivars->weight = weight;
 
     return self;
 }
@@ -77,7 +76,6 @@ PhraseMatcher_Destroy_IMP(PhraseMatcher *self) {
     }
     DECREF(ivars->sim);
     DECREF(ivars->anchor_set);
-    DECREF(ivars->compiler);
     SUPER_DESTROY(self, PHRASEMATCHER);
 }
 

--- a/core/Lucy/Search/PhraseMatcher.cfh
+++ b/core/Lucy/Search/PhraseMatcher.cfh
@@ -28,17 +28,16 @@ class Lucy::Search::PhraseMatcher inherits Lucy::Search::Matcher {
     ByteBuf        *anchor_set;
     float           phrase_freq;
     float           phrase_boost;
-    Compiler       *compiler;
     float           weight;
     bool            first_time;
     bool            more;
 
     inert incremented PhraseMatcher*
-    new(Similarity *similarity, Vector *posting_lists, Compiler *compiler);
+    new(Similarity *similarity, Vector *posting_lists, float weight);
 
     inert PhraseMatcher*
     init(PhraseMatcher *self, Similarity *similarity, Vector *posting_lists,
-         Compiler *compiler);
+         float weight);
 
     public void
     Destroy(PhraseMatcher *self);

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -191,48 +191,57 @@ PhraseQuery_Get_Terms_IMP(PhraseQuery *self) {
 /*********************************************************************/
 
 PhraseCompiler*
-PhraseCompiler_new(PhraseQuery *parent, Searcher *searcher, float boost) {
+PhraseCompiler_new(PhraseQuery *query, Searcher *searcher, float boost) {
     PhraseCompiler *self = (PhraseCompiler*)Class_Make_Obj(PHRASECOMPILER);
-    return PhraseCompiler_init(self, parent, searcher, boost);
+    return PhraseCompiler_init(self, query, searcher, boost);
 }
 
 PhraseCompiler*
-PhraseCompiler_init(PhraseCompiler *self, PhraseQuery *parent,
+PhraseCompiler_init(PhraseCompiler *self, PhraseQuery *query,
                     Searcher *searcher, float boost) {
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
-    PhraseQueryIVARS *const parent_ivars = PhraseQuery_IVARS(parent);
+    PhraseQueryIVARS *const query_ivars = PhraseQuery_IVARS(query);
+    String     *field  = query_ivars->field;
+    Vector     *terms  = query_ivars->terms;
     Schema     *schema = Searcher_Get_Schema(searcher);
-    Similarity *sim    = Schema_Fetch_Sim(schema, parent_ivars->field);
-    Vector     *terms  = parent_ivars->terms;
+    Similarity *sim    = Schema_Fetch_Sim(schema, field);
 
     // Try harder to find a Similarity if necessary.
     if (!sim) { sim = Schema_Get_Similarity(schema); }
 
     // Init.
-    Compiler_init((Compiler*)self, (Query*)parent, searcher, sim, boost);
+    Compiler_init((Compiler*)self);
+    ivars->field = (String*)INCREF(field);
+    ivars->terms = (Vector*)INCREF(terms);
 
     // Store IDF for the phrase.
     ivars->idf = 0;
     for (size_t i = 0, max = Vec_Get_Size(terms); i < max; i++) {
         Obj     *term     = Vec_Fetch(terms, i);
         int32_t  doc_max  = Searcher_Doc_Max(searcher);
-        uint32_t doc_freq = Searcher_Doc_Freq(searcher, parent_ivars->field, term);
+        uint32_t doc_freq = Searcher_Doc_Freq(searcher, field, term);
         ivars->idf += Sim_IDF(sim, (int32_t)doc_freq, doc_max);
     }
 
     // Calculate raw weight.
-    ivars->raw_weight = ivars->idf * ivars->boost;
+    ivars->raw_weight = ivars->idf * boost;
 
     return self;
 }
 
 void
+PhraseCompiler_Destroy_IMP(PhraseCompiler *self) {
+    PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
+    DECREF(ivars->field);
+    DECREF(ivars->terms);
+    SUPER_DESTROY(self, PHRASECOMPILER);
+}
+
+void
 PhraseCompiler_Serialize_IMP(PhraseCompiler *self, OutStream *outstream) {
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
-    PhraseCompiler_Serialize_t super_serialize
-        = (PhraseCompiler_Serialize_t)SUPER_METHOD_PTR(PHRASECOMPILER,
-                                                       LUCY_PhraseCompiler_Serialize);
-    super_serialize(self, outstream);
+    Freezer_serialize_string(ivars->field, outstream);
+    Freezer_serialize_varray(ivars->terms, outstream);
     OutStream_Write_F32(outstream, ivars->idf);
     OutStream_Write_F32(outstream, ivars->raw_weight);
     OutStream_Write_F32(outstream, ivars->query_norm_factor);
@@ -241,37 +250,35 @@ PhraseCompiler_Serialize_IMP(PhraseCompiler *self, OutStream *outstream) {
 
 PhraseCompiler*
 PhraseCompiler_Deserialize_IMP(PhraseCompiler *self, InStream *instream) {
-    PhraseCompiler_Deserialize_t super_deserialize
-        = SUPER_METHOD_PTR(PHRASECOMPILER, LUCY_PhraseCompiler_Deserialize);
-    self = super_deserialize(self, instream);
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
+
+    ivars->field             = Freezer_read_string(instream);
+    ivars->terms             = Freezer_read_varray(instream);
     ivars->idf               = InStream_Read_F32(instream);
     ivars->raw_weight        = InStream_Read_F32(instream);
     ivars->query_norm_factor = InStream_Read_F32(instream);
     ivars->normalized_weight = InStream_Read_F32(instream);
+
+    for (size_t i = 0, max = Vec_Get_Size(ivars->terms); i < max; i++) {
+        CERTIFY(Vec_Fetch(ivars->terms, i), OBJ);
+    }
+
     return self;
 }
 
 bool
 PhraseCompiler_Equals_IMP(PhraseCompiler *self, Obj *other) {
     if (!Obj_is_a(other, PHRASECOMPILER))                     { return false; }
-    PhraseCompiler_Equals_t super_equals
-        = (PhraseCompiler_Equals_t)SUPER_METHOD_PTR(PHRASECOMPILER,
-                                                    LUCY_PhraseCompiler_Equals);
-    if (!super_equals(self, other))                           { return false; }
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
     PhraseCompilerIVARS *const ovars
         = PhraseCompiler_IVARS((PhraseCompiler*)other);
+    if (!Str_Equals(ivars->field, (Obj*)ovars->field))        { return false; }
+    if (!Vec_Equals(ivars->terms, (Obj*)ovars->terms))        { return false; }
     if (ivars->idf != ovars->idf)                             { return false; }
     if (ivars->raw_weight != ovars->raw_weight)               { return false; }
     if (ivars->query_norm_factor != ovars->query_norm_factor) { return false; }
     if (ivars->normalized_weight != ovars->normalized_weight) { return false; }
     return true;
-}
-
-float
-PhraseCompiler_Get_Weight_IMP(PhraseCompiler *self) {
-    return PhraseCompiler_IVARS(self)->normalized_weight;
 }
 
 float
@@ -292,22 +299,11 @@ PhraseCompiler_Make_Matcher_IMP(PhraseCompiler *self, SegReader *reader,
                                 bool need_score) {
     UNUSED_VAR(need_score);
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
-    PhraseQueryIVARS *const parent_ivars
-        = PhraseQuery_IVARS((PhraseQuery*)ivars->parent);
-    Vector *const      terms     = parent_ivars->terms;
+    Vector *const      terms     = ivars->terms;
     size_t             num_terms = Vec_Get_Size(terms);
 
     // Bail if there are no terms.
     if (!num_terms) { return NULL; }
-
-    // Bail unless field is valid and posting type supports positions.
-    Similarity *sim     = PhraseCompiler_Get_Similarity(self);
-    Posting    *posting = Sim_Make_Posting(sim);
-    if (posting == NULL || !Obj_is_a((Obj*)posting, SCOREPOSTING)) {
-        DECREF(posting);
-        return NULL;
-    }
-    DECREF(posting);
 
     // Bail if there's no PostingListReader for this segment.
     PostingListReader *const plist_reader
@@ -315,12 +311,24 @@ PhraseCompiler_Make_Matcher_IMP(PhraseCompiler *self, SegReader *reader,
               reader, Class_Get_Name(POSTINGLISTREADER));
     if (!plist_reader) { return NULL; }
 
+    Schema     *schema = PListReader_Get_Schema(plist_reader);
+    Similarity *sim    = Schema_Fetch_Sim(schema, ivars->field);
+    if (!sim) { sim = Schema_Get_Similarity(schema); }
+
+    // Bail unless field is valid and posting type supports positions.
+    Posting *posting = Sim_Make_Posting(sim);
+    if (posting == NULL || !Obj_is_a((Obj*)posting, SCOREPOSTING)) {
+        DECREF(posting);
+        return NULL;
+    }
+    DECREF(posting);
+
     // Look up each term.
     Vector  *plists = Vec_new(num_terms);
     for (size_t i = 0; i < num_terms; i++) {
         Obj *term = Vec_Fetch(terms, i);
         PostingList *plist
-            = PListReader_Posting_List(plist_reader, parent_ivars->field, term);
+            = PListReader_Posting_List(plist_reader, ivars->field, term);
 
         // Bail if any one of the terms isn't in the index.
         if (!plist || !PList_Get_Doc_Freq(plist)) {
@@ -331,8 +339,8 @@ PhraseCompiler_Make_Matcher_IMP(PhraseCompiler *self, SegReader *reader,
         Vec_Push(plists, (Obj*)plist);
     }
 
-    Matcher *retval
-        = (Matcher*)PhraseMatcher_new(sim, plists, (Compiler*)self);
+    float weight = ivars->normalized_weight;
+    Matcher *retval = (Matcher*)PhraseMatcher_new(sim, plists, weight);
     DECREF(plists);
     return retval;
 }
@@ -341,16 +349,14 @@ Vector*
 PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
                                    DocVector *doc_vec, String *field) {
     PhraseCompilerIVARS *const ivars = PhraseCompiler_IVARS(self);
-    PhraseQueryIVARS *const parent_ivars
-        = PhraseQuery_IVARS((PhraseQuery*)ivars->parent);
-    Vector *const      terms     = parent_ivars->terms;
+    Vector *const      terms     = ivars->terms;
     Vector *const      spans     = Vec_new(0);
     const uint32_t     num_terms = (uint32_t)Vec_Get_Size(terms);
     UNUSED_VAR(searcher);
 
     // Bail if no terms or field doesn't match.
     if (!num_terms) { return spans; }
-    if (!Str_Equals(field, (Obj*)parent_ivars->field)) { return spans; }
+    if (!Str_Equals(field, (Obj*)ivars->field)) { return spans; }
 
     Vector *term_vectors    = Vec_new(num_terms);
     BitVector *posit_vec       = BitVec_new(0);
@@ -403,7 +409,7 @@ PhraseCompiler_Highlight_Spans_IMP(PhraseCompiler *self, Searcher *searcher,
         I32Array *valid_posits       = BitVec_To_Array(posit_vec);
         size_t    num_valid_posits   = I32Arr_Get_Size(valid_posits);
         size_t j = 0;
-        float weight = PhraseCompiler_Get_Weight(self);
+        float weight = ivars->normalized_weight;
         size_t i = 0;
 
         // Add only those starts/ends that belong to a valid position.

--- a/core/Lucy/Search/PhraseQuery.c
+++ b/core/Lucy/Search/PhraseQuery.c
@@ -159,7 +159,7 @@ PhraseQuery_To_String_IMP(PhraseQuery *self) {
 
 Compiler*
 PhraseQuery_Make_Compiler_IMP(PhraseQuery *self, Searcher *searcher,
-                              float boost, bool subordinate) {
+                              float boost) {
     PhraseQueryIVARS *const ivars = PhraseQuery_IVARS(self);
     if (Vec_Get_Size(ivars->terms) == 1) {
         // Optimize for one-term "phrases".
@@ -169,17 +169,12 @@ PhraseQuery_Make_Compiler_IMP(PhraseQuery *self, Searcher *searcher,
         TermQuery_Set_Boost(term_query, ivars->boost);
         term_compiler
             = (TermCompiler*)TermQuery_Make_Compiler(term_query, searcher,
-                                                     boost, subordinate);
+                                                     boost);
         DECREF(term_query);
         return (Compiler*)term_compiler;
     }
     else {
-        PhraseCompiler *compiler
-            = PhraseCompiler_new(self, searcher, boost);
-        if (!subordinate) {
-            PhraseCompiler_Normalize(compiler);
-        }
-        return (Compiler*)compiler;
+        return (Compiler*)PhraseCompiler_new(self, searcher, boost);
     }
 }
 

--- a/core/Lucy/Search/PhraseQuery.cfh
+++ b/core/Lucy/Search/PhraseQuery.cfh
@@ -54,8 +54,7 @@ public class Lucy::Search::PhraseQuery inherits Lucy::Search::Query {
     Get_Terms(PhraseQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(PhraseQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(PhraseQuery *self, Searcher *searcher, float boost);
 
     public bool
     Equals(PhraseQuery *self, Obj *other);

--- a/core/Lucy/Search/PhraseQuery.cfh
+++ b/core/Lucy/Search/PhraseQuery.cfh
@@ -81,23 +81,22 @@ public class Lucy::Search::PhraseQuery inherits Lucy::Search::Query {
 class Lucy::Search::PhraseCompiler
     inherits Lucy::Search::Compiler {
 
-    float idf;
-    float raw_weight;
-    float query_norm_factor;
-    float normalized_weight;
+    String *field;
+    Vector *terms;
+    float   idf;
+    float   raw_weight;
+    float   query_norm_factor;
+    float   normalized_weight;
 
     inert incremented PhraseCompiler*
-    new(PhraseQuery *parent, Searcher *searcher, float boost);
+    new(PhraseQuery *query, Searcher *searcher, float boost);
 
     inert PhraseCompiler*
-    init(PhraseCompiler *self, PhraseQuery *parent, Searcher *searcher,
+    init(PhraseCompiler *self, PhraseQuery *query, Searcher *searcher,
          float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(PhraseCompiler *self, SegReader *reader, bool need_score);
-
-    public float
-    Get_Weight(PhraseCompiler *self);
 
     public float
     Sum_Of_Squared_Weights(PhraseCompiler *self);
@@ -117,6 +116,9 @@ class Lucy::Search::PhraseCompiler
 
     incremented PhraseCompiler*
     Deserialize(decremented PhraseCompiler *self, InStream *instream);
+
+    public void
+    Destroy(PhraseCompiler *self);
 }
 
 

--- a/core/Lucy/Search/PolyQuery.c
+++ b/core/Lucy/Search/PolyQuery.c
@@ -144,7 +144,7 @@ PolyCompiler_init(PolyCompiler *self, PolyQuery *parent,
         Query *child_query = (Query*)Vec_Fetch(parent_ivars->children, i);
         float sub_boost = boost * Query_Get_Boost(child_query);
         Compiler *child_compiler
-            = Query_Make_Compiler(child_query, searcher, sub_boost, true);
+            = Query_Make_Compiler(child_query, searcher, sub_boost);
         Vec_Push(ivars->children, (Obj*)child_compiler);
     }
 

--- a/core/Lucy/Search/PolyQuery.cfh
+++ b/core/Lucy/Search/PolyQuery.cfh
@@ -70,12 +70,13 @@ public abstract class Lucy::Search::PolyQuery inherits Lucy::Search::Query {
 abstract class Lucy::Search::PolyCompiler inherits Lucy::Search::Compiler {
 
     Vector *children;
+    float   boost;
 
     /** Initialize the Compiler, creating a Compiler child for each child
      * Query.  Normalization is left to the subclass.
      */
     inert PolyCompiler*
-    init(PolyCompiler *self, PolyQuery *parent, Searcher *searcher,
+    init(PolyCompiler *self, PolyQuery *query, Searcher *searcher,
          float boost);
 
     public float
@@ -87,6 +88,9 @@ abstract class Lucy::Search::PolyCompiler inherits Lucy::Search::Compiler {
     incremented Vector*
     Highlight_Spans(PolyCompiler *self, Searcher *searcher,
                     DocVector *doc_vec, String *field);
+
+    public bool
+    Equals(PolyCompiler *self, Obj *other);
 
     public void
     Destroy(PolyCompiler *self);

--- a/core/Lucy/Search/PolySearcher.c
+++ b/core/Lucy/Search/PolySearcher.c
@@ -136,8 +136,8 @@ S_modify_doc_ids(Vector *match_docs, int32_t base) {
 }
 
 TopDocs*
-PolySearcher_Top_Docs_IMP(PolySearcher *self, Query *query,
-                          uint32_t num_wanted, SortSpec *sort_spec) {
+PolySearcher_Top_Docs_IMP(PolySearcher *self, Obj *query, uint32_t num_wanted,
+                          SortSpec *sort_spec) {
     PolySearcherIVARS *const ivars = PolySearcher_IVARS(self);
     Schema   *schema      = PolySearcher_Get_Schema(self);
     Vector   *searchers   = ivars->searchers;
@@ -146,14 +146,23 @@ PolySearcher_Top_Docs_IMP(PolySearcher *self, Query *query,
                             ? HitQ_new(schema, sort_spec, num_wanted)
                             : HitQ_new(NULL, NULL, num_wanted);
     uint32_t  total_hits  = 0;
-    Compiler *compiler    = Query_is_a(query, COMPILER)
-                            ? ((Compiler*)INCREF(query))
-                            : Query_Make_Root_Compiler(query, (Searcher*)self);
+    Compiler *compiler;
+
+    if (Obj_is_a(query, QUERY)) {
+        compiler = Query_Make_Root_Compiler((Query*)query, (Searcher*)self);
+    }
+    else if (Obj_is_a(query, COMPILER)) {
+        compiler = (Compiler*)INCREF(query);
+    }
+    else {
+        THROW(ERR, "Invalid query type: %o", Obj_get_class_name(query));
+        UNREACHABLE_RETURN(TopDocs*);
+    }
 
     for (size_t i = 0, max = Vec_Get_Size(searchers); i < max; i++) {
         Searcher   *searcher   = (Searcher*)Vec_Fetch(searchers, i);
         int32_t     base       = I32Arr_Get(starts, i);
-        TopDocs    *top_docs   = Searcher_Top_Docs(searcher, (Query*)compiler,
+        TopDocs    *top_docs   = Searcher_Top_Docs(searcher, (Obj*)compiler,
                                                    num_wanted, sort_spec);
         Vector     *sub_match_docs = TopDocs_Get_Match_Docs(top_docs);
 
@@ -179,7 +188,7 @@ PolySearcher_Top_Docs_IMP(PolySearcher *self, Query *query,
 
 
 void
-PolySearcher_Collect_IMP(PolySearcher *self, Query *query,
+PolySearcher_Collect_IMP(PolySearcher *self, Obj *query,
                          Collector *collector) {
     PolySearcherIVARS *const ivars = PolySearcher_IVARS(self);
     Vector *const searchers = ivars->searchers;

--- a/core/Lucy/Search/PolySearcher.c
+++ b/core/Lucy/Search/PolySearcher.c
@@ -148,9 +148,7 @@ PolySearcher_Top_Docs_IMP(PolySearcher *self, Query *query,
     uint32_t  total_hits  = 0;
     Compiler *compiler    = Query_is_a(query, COMPILER)
                             ? ((Compiler*)INCREF(query))
-                            : Query_Make_Compiler(query, (Searcher*)self,
-                                                  Query_Get_Boost(query),
-                                                  false);
+                            : Query_Make_Root_Compiler(query, (Searcher*)self);
 
     for (size_t i = 0, max = Vec_Get_Size(searchers); i < max; i++) {
         Searcher   *searcher   = (Searcher*)Vec_Fetch(searchers, i);

--- a/core/Lucy/Search/PolySearcher.cfh
+++ b/core/Lucy/Search/PolySearcher.cfh
@@ -60,10 +60,10 @@ public class Lucy::Search::PolySearcher
     Doc_Freq(PolySearcher *self, String *field, Obj *term);
 
     public void
-    Collect(PolySearcher *self, Query *query, Collector *collector);
+    Collect(PolySearcher *self, Obj *query, Collector *collector);
 
     incremented TopDocs*
-    Top_Docs(PolySearcher *self, Query *query, uint32_t num_wanted,
+    Top_Docs(PolySearcher *self, Obj *query, uint32_t num_wanted,
              SortSpec *sort_spec = NULL);
 
     public incremented HitDoc*

--- a/core/Lucy/Search/Query.c
+++ b/core/Lucy/Search/Query.c
@@ -18,6 +18,8 @@
 #include "Lucy/Util/ToolSet.h"
 
 #include "Lucy/Search/Query.h"
+#include "Lucy/Index/Similarity.h"
+#include "Lucy/Plan/Schema.h"
 #include "Lucy/Search/Compiler.h"
 #include "Lucy/Search/Searcher.h"
 #include "Lucy/Store/InStream.h"
@@ -35,7 +37,11 @@ Compiler*
 Query_Make_Root_Compiler_IMP(Query *self, Searcher *searcher) {
     Compiler *compiler
         = Query_Make_Compiler(self, searcher, Query_Get_Boost(self));
-    Compiler_Normalize(compiler);
+
+    Schema     *schema = Searcher_Get_Schema(searcher);
+    Similarity *sim    = Schema_Get_Similarity(schema);
+    Compiler_Normalize(compiler, sim);
+
     return compiler;
 }
 

--- a/core/Lucy/Search/Query.cfh
+++ b/core/Lucy/Search/Query.cfh
@@ -48,18 +48,24 @@ public class Lucy::Search::Query inherits Clownfish::Obj {
     public inert Query*
     init(Query *self, float boost = 1.0);
 
+    /** Derive a Compiler from the Query and normalize it.
+     */
+    public incremented Compiler*
+    Make_Root_Compiler(Query *self, Searcher *searcher);
+
     /** Abstract factory method returning a Compiler derived from this Query.
      *
      * @param searcher A Searcher.
      * @param boost A scoring multiplier.
-     * @param subordinate Indicates whether the Query is a subquery (as
-     * opposed to a top-level query).  If false, the implementation must
-     * invoke [](cfish:Compiler.Normalize) on the newly minted Compiler object before returning
-     * it.
      */
-    public abstract incremented Compiler*
-    Make_Compiler(Query *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    public incremented Compiler*
+    Make_Compiler(Query *self, Searcher *searcher, float boost);
+
+    /** For backward compatibility with old API.
+     */
+    incremented Compiler*
+    Make_Compiler_Compat(Query *self, Searcher *searcher, float boost,
+                         bool subordinate = false);
 
     /** Set the Query's boost.
      */

--- a/core/Lucy/Search/RangeQuery.c
+++ b/core/Lucy/Search/RangeQuery.c
@@ -214,12 +214,8 @@ RangeQuery_Load_IMP(RangeQuery *self, Obj *dump) {
 
 Compiler*
 RangeQuery_Make_Compiler_IMP(RangeQuery *self, Searcher *searcher,
-                             float boost, bool subordinate) {
-    RangeCompiler *compiler = RangeCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        RangeCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+                             float boost) {
+    return (Compiler*)RangeCompiler_new(self, searcher, boost);
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/RangeQuery.cfh
+++ b/core/Lucy/Search/RangeQuery.cfh
@@ -84,15 +84,29 @@ public class Lucy::Search::RangeQuery inherits Lucy::Search::Query {
 
 class Lucy::Search::RangeCompiler inherits Lucy::Search::Compiler {
 
+    RangeQuery *query;
+    float boost;
+
     inert incremented RangeCompiler*
-    new(RangeQuery *parent, Searcher *searcher, float boost);
+    new(RangeQuery *query, float boost);
 
     inert RangeCompiler*
-    init(RangeCompiler *self, RangeQuery *parent, Searcher *searcher,
-         float boost);
+    init(RangeCompiler *self, RangeQuery *query, float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(RangeCompiler *self, SegReader *reader, bool need_score);
+
+    public bool
+    Equals(RangeCompiler *self, Obj *other);
+
+    public void
+    Destroy(RangeCompiler *self);
+
+    void
+    Serialize(RangeCompiler *self, OutStream *outstream);
+
+    incremented RangeCompiler*
+    Deserialize(decremented RangeCompiler *self, InStream *instream);
 }
 
 

--- a/core/Lucy/Search/RangeQuery.cfh
+++ b/core/Lucy/Search/RangeQuery.cfh
@@ -64,8 +64,7 @@ public class Lucy::Search::RangeQuery inherits Lucy::Search::Query {
     To_String(RangeQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(RangeQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(RangeQuery *self, Searcher *searcher, float boost);
 
     void
     Serialize(RangeQuery *self, OutStream *outstream);

--- a/core/Lucy/Search/RequiredOptionalQuery.c
+++ b/core/Lucy/Search/RequiredOptionalQuery.c
@@ -91,13 +91,8 @@ ReqOptQuery_Equals_IMP(RequiredOptionalQuery *self, Obj *other) {
 
 Compiler*
 ReqOptQuery_Make_Compiler_IMP(RequiredOptionalQuery *self, Searcher *searcher,
-                              float boost, bool subordinate) {
-    RequiredOptionalCompiler *compiler
-        = ReqOptCompiler_new(self, searcher, boost);
-    if (!subordinate) {
-        ReqOptCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
+                              float boost) {
+    return (Compiler*)ReqOptCompiler_new(self, searcher, boost);
 }
 
 /**********************************************************************/

--- a/core/Lucy/Search/RequiredOptionalQuery.c
+++ b/core/Lucy/Search/RequiredOptionalQuery.c
@@ -98,21 +98,29 @@ ReqOptQuery_Make_Compiler_IMP(RequiredOptionalQuery *self, Searcher *searcher,
 /**********************************************************************/
 
 RequiredOptionalCompiler*
-ReqOptCompiler_new(RequiredOptionalQuery *parent, Searcher *searcher,
+ReqOptCompiler_new(RequiredOptionalQuery *query, Searcher *searcher,
                    float boost) {
     RequiredOptionalCompiler *self
         = (RequiredOptionalCompiler*)Class_Make_Obj(
               REQUIREDOPTIONALCOMPILER);
-    return ReqOptCompiler_init(self, parent, searcher, boost);
+    return ReqOptCompiler_init(self, query, searcher, boost);
 }
 
 RequiredOptionalCompiler*
 ReqOptCompiler_init(RequiredOptionalCompiler *self,
-                    RequiredOptionalQuery *parent,
+                    RequiredOptionalQuery *query,
                     Searcher *searcher, float boost) {
-    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)parent, searcher,
-                      boost);
+    PolyCompiler_init((PolyCompiler*)self, (PolyQuery*)query, searcher, boost);
     return self;
+}
+
+bool
+ReqOptCompiler_Equals_IMP(RequiredOptionalCompiler *self, Obj *other) {
+    if ((RequiredOptionalCompiler*)other == self)   { return true;  }
+    if (!Obj_is_a(other, REQUIREDOPTIONALCOMPILER)) { return false; }
+    ReqOptCompiler_Equals_t super_equals = (ReqOptCompiler_Equals_t)
+        SUPER_METHOD_PTR(REQUIREDOPTIONALCOMPILER, LUCY_ReqOptCompiler_Equals);
+    return super_equals(self, other);
 }
 
 Matcher*

--- a/core/Lucy/Search/RequiredOptionalQuery.cfh
+++ b/core/Lucy/Search/RequiredOptionalQuery.cfh
@@ -74,15 +74,18 @@ class Lucy::Search::RequiredOptionalCompiler nickname ReqOptCompiler
     inherits Lucy::Search::PolyCompiler {
 
     inert incremented RequiredOptionalCompiler*
-    new(RequiredOptionalQuery *parent, Searcher *searcher, float boost);
+    new(RequiredOptionalQuery *query, Searcher *searcher, float boost);
 
     inert RequiredOptionalCompiler*
-    init(RequiredOptionalCompiler *self, RequiredOptionalQuery *parent,
+    init(RequiredOptionalCompiler *self, RequiredOptionalQuery *query,
          Searcher *searcher, float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(RequiredOptionalCompiler *self, SegReader *reader,
                  bool need_score);
+
+    public bool
+    Equals(RequiredOptionalCompiler *self, Obj *other);
 }
 
 

--- a/core/Lucy/Search/RequiredOptionalQuery.cfh
+++ b/core/Lucy/Search/RequiredOptionalQuery.cfh
@@ -61,7 +61,7 @@ public class Lucy::Search::RequiredOptionalQuery nickname ReqOptQuery
 
     public incremented Compiler*
     Make_Compiler(RequiredOptionalQuery *self, Searcher *searcher,
-                  float boost, bool subordinate = false);
+                  float boost);
 
     public incremented String*
     To_String(RequiredOptionalQuery *self);

--- a/core/Lucy/Search/Searcher.c
+++ b/core/Lucy/Search/Searcher.c
@@ -55,7 +55,7 @@ Searcher_Hits_IMP(Searcher *self, Obj *query, uint32_t offset,
     uint32_t wanted     = offset + num_wanted > doc_max
                           ? doc_max
                           : offset + num_wanted;
-    TopDocs *top_docs   = Searcher_Top_Docs(self, real_query, wanted,
+    TopDocs *top_docs   = Searcher_Top_Docs(self, (Obj*)real_query, wanted,
                                             sort_spec);
     Hits    *hits       = Hits_new(self, top_docs, offset);
     DECREF(top_docs);

--- a/core/Lucy/Search/Searcher.cfh
+++ b/core/Lucy/Search/Searcher.cfh
@@ -81,16 +81,16 @@ public class Lucy::Search::Searcher inherits Clownfish::Obj {
     /** Iterate over hits, feeding them into a
      * [](cfish:Collector).
      *
-     * @param query A Query.
+     * @param query A Query or a Compiler.
      * @param collector A Collector.
      */
     public abstract void
-    Collect(Searcher *self, Query *query, Collector *collector);
+    Collect(Searcher *self, Obj *query, Collector *collector);
 
     /** Return a TopDocs object with up to num_wanted hits.
      */
     abstract incremented TopDocs*
-    Top_Docs(Searcher *self, Query *query, uint32_t num_wanted,
+    Top_Docs(Searcher *self, Obj *query, uint32_t num_wanted,
              SortSpec *sort_spec = NULL);
 
     /** Retrieve a document.  Throws an error if the doc id is out of range.

--- a/core/Lucy/Search/TermMatcher.c
+++ b/core/Lucy/Search/TermMatcher.c
@@ -25,15 +25,14 @@
 
 TermMatcher*
 TermMatcher_init(TermMatcher *self, Similarity *similarity, PostingList *plist,
-                 Compiler *compiler) {
+                 float weight) {
     Matcher_init((Matcher*)self);
     TermMatcherIVARS *const ivars = TermMatcher_IVARS(self);
 
     // Assign.
     ivars->sim           = (Similarity*)INCREF(similarity);
     ivars->plist         = (PostingList*)INCREF(plist);
-    ivars->compiler      = (Compiler*)INCREF(compiler);
-    ivars->weight        = Compiler_Get_Weight(compiler);
+    ivars->weight        = weight;
 
     // Init.
     ivars->posting        = NULL;
@@ -46,7 +45,6 @@ TermMatcher_Destroy_IMP(TermMatcher *self) {
     TermMatcherIVARS *const ivars = TermMatcher_IVARS(self);
     DECREF(ivars->sim);
     DECREF(ivars->plist);
-    DECREF(ivars->compiler);
     SUPER_DESTROY(self, TERMMATCHER);
 }
 

--- a/core/Lucy/Search/TermMatcher.c
+++ b/core/Lucy/Search/TermMatcher.c
@@ -24,13 +24,11 @@
 #include "Lucy/Search/Compiler.h"
 
 TermMatcher*
-TermMatcher_init(TermMatcher *self, Similarity *similarity, PostingList *plist,
-                 float weight) {
+TermMatcher_init(TermMatcher *self, PostingList *plist, float weight) {
     Matcher_init((Matcher*)self);
     TermMatcherIVARS *const ivars = TermMatcher_IVARS(self);
 
     // Assign.
-    ivars->sim           = (Similarity*)INCREF(similarity);
     ivars->plist         = (PostingList*)INCREF(plist);
     ivars->weight        = weight;
 
@@ -43,7 +41,6 @@ TermMatcher_init(TermMatcher *self, Similarity *similarity, PostingList *plist,
 void
 TermMatcher_Destroy_IMP(TermMatcher *self) {
     TermMatcherIVARS *const ivars = TermMatcher_IVARS(self);
-    DECREF(ivars->sim);
     DECREF(ivars->plist);
     SUPER_DESTROY(self, TERMMATCHER);
 }

--- a/core/Lucy/Search/TermMatcher.cfh
+++ b/core/Lucy/Search/TermMatcher.cfh
@@ -25,14 +25,13 @@ parcel Lucy;
 class Lucy::Search::TermMatcher inherits Lucy::Search::Matcher {
 
     float           weight;
-    Compiler       *compiler;
     Similarity     *sim;
     PostingList    *plist;
     Posting        *posting;
 
     inert TermMatcher*
     init(TermMatcher *self, Similarity *similarity, PostingList *posting_list,
-         Compiler *compiler);
+         float weight);
 
     public void
     Destroy(TermMatcher *self);

--- a/core/Lucy/Search/TermMatcher.cfh
+++ b/core/Lucy/Search/TermMatcher.cfh
@@ -25,13 +25,11 @@ parcel Lucy;
 class Lucy::Search::TermMatcher inherits Lucy::Search::Matcher {
 
     float           weight;
-    Similarity     *sim;
     PostingList    *plist;
     Posting        *posting;
 
     inert TermMatcher*
-    init(TermMatcher *self, Similarity *similarity, PostingList *posting_list,
-         float weight);
+    init(TermMatcher *self, PostingList *posting_list, float weight);
 
     public void
     Destroy(TermMatcher *self);

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -276,8 +276,7 @@ TermCompiler_Make_Matcher_IMP(TermCompiler *self, SegReader *reader,
     }
     else {
         float weight = ivars->normalized_weight;
-        Matcher *retval = PList_Make_Matcher(plist, ivars->sim, weight,
-                                             need_score);
+        Matcher *retval = PList_Make_Matcher(plist, weight, need_score);
         DECREF(plist);
         return retval;
     }

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -258,6 +258,7 @@ TermCompiler_Get_Weight_IMP(TermCompiler *self) {
 Matcher*
 TermCompiler_Make_Matcher_IMP(TermCompiler *self, SegReader *reader,
                               bool need_score) {
+    UNUSED_VAR(need_score);
     TermCompilerIVARS *const ivars = TermCompiler_IVARS(self);
     TermQueryIVARS *const parent_ivars
         = TermQuery_IVARS((TermQuery*)ivars->parent);
@@ -276,7 +277,7 @@ TermCompiler_Make_Matcher_IMP(TermCompiler *self, SegReader *reader,
     }
     else {
         float weight = ivars->normalized_weight;
-        Matcher *retval = PList_Make_Matcher(plist, weight, need_score);
+        Matcher *retval = PList_Make_Matcher(plist, weight);
         DECREF(plist);
         return retval;
     }

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -235,6 +235,11 @@ TermCompiler_Sum_Of_Squared_Weights_IMP(TermCompiler *self) {
     return ivars->raw_weight * ivars->raw_weight;
 }
 
+float
+TermCompiler_Get_Weight_IMP(TermCompiler *self) {
+    return TermCompiler_IVARS(self)->normalized_weight;
+}
+
 void
 TermCompiler_Apply_Norm_Factor_IMP(TermCompiler *self,
                                    float query_norm_factor) {

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -131,14 +131,8 @@ TermQuery_To_String_IMP(TermQuery *self) {
 }
 
 Compiler*
-TermQuery_Make_Compiler_IMP(TermQuery *self, Searcher *searcher, float boost,
-                            bool subordinate) {
-    TermCompiler *compiler = TermCompiler_new((Query*)self, searcher, boost);
-    if (!subordinate) {
-        TermCompiler_Normalize(compiler);
-    }
-    return (Compiler*)compiler;
-
+TermQuery_Make_Compiler_IMP(TermQuery *self, Searcher *searcher, float boost) {
+    return (Compiler*)TermCompiler_new((Query*)self, searcher, boost);
 }
 
 /******************************************************************/

--- a/core/Lucy/Search/TermQuery.c
+++ b/core/Lucy/Search/TermQuery.c
@@ -275,8 +275,9 @@ TermCompiler_Make_Matcher_IMP(TermCompiler *self, SegReader *reader,
         return NULL;
     }
     else {
-        Matcher *retval = PList_Make_Matcher(plist, ivars->sim,
-                                             (Compiler*)self, need_score);
+        float weight = ivars->normalized_weight;
+        Matcher *retval = PList_Make_Matcher(plist, ivars->sim, weight,
+                                             need_score);
         DECREF(plist);
         return retval;
     }

--- a/core/Lucy/Search/TermQuery.cfh
+++ b/core/Lucy/Search/TermQuery.cfh
@@ -55,8 +55,7 @@ public class Lucy::Search::TermQuery inherits Lucy::Search::Query {
     Get_Term(TermQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(TermQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(TermQuery *self, Searcher *searcher, float boost);
 
     public incremented String*
     To_String(TermQuery *self);

--- a/core/Lucy/Search/TermQuery.cfh
+++ b/core/Lucy/Search/TermQuery.cfh
@@ -80,23 +80,22 @@ public class Lucy::Search::TermQuery inherits Lucy::Search::Query {
 }
 
 class Lucy::Search::TermCompiler inherits Lucy::Search::Compiler {
-    float idf;
-    float raw_weight;
-    float query_norm_factor;
-    float normalized_weight;
+    String *field;
+    Obj    *term;
+    float   idf;
+    float   raw_weight;
+    float   query_norm_factor;
+    float   normalized_weight;
 
     inert incremented TermCompiler*
-    new(Query *parent, Searcher *searcher, float boost);
+    new(TermQuery *query, Searcher *searcher, float boost);
 
     inert TermCompiler*
-    init(TermCompiler *self, Query *parent, Searcher *searcher,
+    init(TermCompiler *self, TermQuery *query, Searcher *searcher,
          float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(TermCompiler *self, SegReader *reader, bool need_score);
-
-    public float
-    Get_Weight(TermCompiler *self);
 
     public float
     Sum_Of_Squared_Weights(TermCompiler *self);
@@ -116,6 +115,9 @@ class Lucy::Search::TermCompiler inherits Lucy::Search::Compiler {
 
     incremented TermCompiler*
     Deserialize(decremented TermCompiler *self, InStream *instream);
+
+    public void
+    Destroy(TermCompiler *self);
 }
 
 

--- a/core/Lucy/Search/TermQuery.cfh
+++ b/core/Lucy/Search/TermQuery.cfh
@@ -100,6 +100,11 @@ class Lucy::Search::TermCompiler inherits Lucy::Search::Compiler {
     public float
     Sum_Of_Squared_Weights(TermCompiler *self);
 
+    /** Test-only.
+     */
+    float
+    Get_Weight(TermCompiler *self);
+
     public void
     Apply_Norm_Factor(TermCompiler *self, float factor);
 

--- a/core/Lucy/Util/Freezer.c
+++ b/core/Lucy/Util/Freezer.c
@@ -31,6 +31,7 @@
 #include "Lucy/Index/TermVector.h"
 #include "Lucy/Plan/FieldType.h"
 #include "Lucy/Plan/Schema.h"
+#include "Lucy/Search/Compiler.h"
 #include "Lucy/Search/Query.h"
 #include "Lucy/Search/SortRule.h"
 #include "Lucy/Search/SortSpec.h"
@@ -94,6 +95,9 @@ Freezer_serialize(Obj *obj, OutStream *outstream) {
     else if (Obj_is_a(obj, QUERY)) {
         Query_Serialize((Query*)obj, outstream);
     }
+    else if (Obj_is_a(obj, COMPILER)) {
+        Compiler_Serialize((Compiler*)obj, outstream);
+    }
     else if (Obj_is_a(obj, DOC)) {
         Doc_Serialize((Doc*)obj, outstream);
     }
@@ -148,6 +152,9 @@ Freezer_deserialize(Obj *obj, InStream *instream) {
     }
     else if (Obj_is_a(obj, QUERY)) {
         obj = (Obj*)Query_Deserialize((Query*)obj, instream);
+    }
+    else if (Obj_is_a(obj, COMPILER)) {
+        obj = (Obj*)Compiler_Deserialize((Compiler*)obj, instream);
     }
     else if (Obj_is_a(obj, DOC)) {
         obj = (Obj*)Doc_Deserialize((Doc*)obj, instream);

--- a/core/LucyX/Search/ProximityMatcher.c
+++ b/core/LucyX/Search/ProximityMatcher.c
@@ -27,17 +27,17 @@
 
 
 ProximityMatcher*
-ProximityMatcher_new(Similarity *sim, Vector *plists, Compiler *compiler,
+ProximityMatcher_new(Similarity *sim, Vector *plists, float weight,
                      uint32_t within) {
     ProximityMatcher *self =
         (ProximityMatcher*)Class_Make_Obj(PROXIMITYMATCHER);
-    return ProximityMatcher_init(self, sim, plists, compiler, within);
+    return ProximityMatcher_init(self, sim, plists, weight, within);
 
 }
 
 ProximityMatcher*
 ProximityMatcher_init(ProximityMatcher *self, Similarity *similarity,
-                      Vector *plists, Compiler *compiler, uint32_t within) {
+                      Vector *plists, float weight, uint32_t within) {
     Matcher_init((Matcher*)self);
     ProximityMatcherIVARS *const ivars = ProximityMatcher_IVARS(self);
 
@@ -63,9 +63,8 @@ ProximityMatcher_init(ProximityMatcher *self, Similarity *similarity,
     }
 
     // Assign.
-    ivars->sim       = (Similarity*)INCREF(similarity);
-    ivars->compiler  = (Compiler*)INCREF(compiler);
-    ivars->weight    = Compiler_Get_Weight(compiler);
+    ivars->sim    = (Similarity*)INCREF(similarity);
+    ivars->weight = weight;
 
     return self;
 }
@@ -81,7 +80,6 @@ ProximityMatcher_Destroy_IMP(ProximityMatcher *self) {
     }
     DECREF(ivars->sim);
     DECREF(ivars->anchor_set);
-    DECREF(ivars->compiler);
     SUPER_DESTROY(self, PROXIMITYMATCHER);
 }
 

--- a/core/LucyX/Search/ProximityMatcher.cfh
+++ b/core/LucyX/Search/ProximityMatcher.cfh
@@ -28,19 +28,18 @@ class LucyX::Search::ProximityMatcher inherits Lucy::Search::Matcher {
     ByteBuf        *anchor_set;
     float           proximity_freq;
     float           proximity_boost;
-    Compiler       *compiler;
     float           weight;
     bool            first_time;
     bool            more;
     uint32_t        within;
 
     inert incremented ProximityMatcher*
-    new(Similarity *similarity, Vector *posting_lists, Compiler *compiler,
+    new(Similarity *similarity, Vector *posting_lists, float weight,
         uint32_t within);
 
     inert ProximityMatcher*
     init(ProximityMatcher *self, Similarity *similarity, Vector *posting_lists,
-         Compiler *compiler, uint32_t within);
+         float weight, uint32_t within);
 
     public void
     Destroy(ProximityMatcher *self);

--- a/core/LucyX/Search/ProximityQuery.c
+++ b/core/LucyX/Search/ProximityQuery.c
@@ -172,7 +172,7 @@ ProximityQuery_To_String_IMP(ProximityQuery *self) {
 
 Compiler*
 ProximityQuery_Make_Compiler_IMP(ProximityQuery *self, Searcher *searcher,
-                                 float boost, bool subordinate) {
+                                 float boost) {
     ProximityQueryIVARS *const ivars = ProximityQuery_IVARS(self);
     if (Vec_Get_Size(ivars->terms) == 1) {
         // Optimize for one-term "phrases".
@@ -181,17 +181,13 @@ ProximityQuery_Make_Compiler_IMP(ProximityQuery *self, Searcher *searcher,
         TermQuery_Set_Boost(term_query, ivars->boost);
         TermCompiler *term_compiler
             = (TermCompiler*)TermQuery_Make_Compiler(term_query, searcher,
-                                                     boost, subordinate);
+                                                     boost);
         DECREF(term_query);
         return (Compiler*)term_compiler;
     }
     else {
-        ProximityCompiler *compiler
-            = ProximityCompiler_new(self, searcher, boost, ivars->within);
-        if (!subordinate) {
-            ProximityCompiler_Normalize(compiler);
-        }
-        return (Compiler*)compiler;
+        return (Compiler*)ProximityCompiler_new(self, searcher, boost,
+                                                ivars->within);
     }
 }
 

--- a/core/LucyX/Search/ProximityQuery.cfh
+++ b/core/LucyX/Search/ProximityQuery.cfh
@@ -60,8 +60,7 @@ public class LucyX::Search::ProximityQuery inherits Lucy::Search::Query {
     Get_Within(ProximityQuery *self);
 
     public incremented Compiler*
-    Make_Compiler(ProximityQuery *self, Searcher *searcher, float boost,
-                  bool subordinate = false);
+    Make_Compiler(ProximityQuery *self, Searcher *searcher, float boost);
 
     public bool
     Equals(ProximityQuery *self, Obj *other);

--- a/core/LucyX/Search/ProximityQuery.cfh
+++ b/core/LucyX/Search/ProximityQuery.cfh
@@ -87,24 +87,23 @@ public class LucyX::Search::ProximityQuery inherits Lucy::Search::Query {
 class LucyX::Search::ProximityCompiler
     inherits Lucy::Search::Compiler {
 
-    float    idf;
-    float    raw_weight;
-    float    query_norm_factor;
-    float    normalized_weight;
-    uint32_t within;
+    String   *field;
+    Vector   *terms;
+    float     idf;
+    float     raw_weight;
+    float     query_norm_factor;
+    float     normalized_weight;
+    uint32_t  within;
 
     inert incremented ProximityCompiler*
-    new(ProximityQuery *parent, Searcher *searcher, float boost, uint32_t within);
+    new(ProximityQuery *query, Searcher *searcher, float boost);
 
     inert ProximityCompiler*
-    init(ProximityCompiler *self, ProximityQuery *parent, Searcher *searcher,
-         float boost, uint32_t within);
+    init(ProximityCompiler *self, ProximityQuery *query, Searcher *searcher,
+         float boost);
 
     public incremented nullable Matcher*
     Make_Matcher(ProximityCompiler *self, SegReader *reader, bool need_score);
-
-    public float
-    Get_Weight(ProximityCompiler *self);
 
     public float
     Sum_Of_Squared_Weights(ProximityCompiler *self);
@@ -124,6 +123,9 @@ class LucyX::Search::ProximityCompiler
 
     incremented ProximityCompiler*
     Deserialize(decremented ProximityCompiler *self, InStream *instream);
+
+    public void
+    Destroy(ProximityCompiler *self);
 }
 
 

--- a/go/build.go
+++ b/go/build.go
@@ -315,7 +315,7 @@ func specClasses(parcel *cfc.Parcel) {
 	hitsBinding.Register()
 
 	queryBinding := cfc.NewGoClass(parcel, "Lucy::Search::Query")
-	queryBinding.SpecMethod("Make_Compiler", "MakeCompiler(Searcher, float32, bool) (Compiler, error)")
+	queryBinding.SpecMethod("Make_Root_Compiler", "MakeRootCompiler(Searcher) (Compiler, error)")
 	queryBinding.Register()
 
 	compilerBinding := cfc.NewGoClass(parcel, "Lucy::Search::Compiler")

--- a/go/lucy/highlight_test.go
+++ b/go/lucy/highlight_test.go
@@ -73,10 +73,6 @@ func TestHighlighterAccessors(t *testing.T) {
 	if _, ok := hl.GetSearcher().(Searcher); !ok {
 		t.Errorf("GetSearcher")
 	}
-	barQuery := NewTermQuery("content", "bar")
-	if got := hl.GetQuery(); !barQuery.Equals(got) {
-		t.Errorf("GetQuery: %T %v", got, got)
-	}
 	if _, ok := hl.GetCompiler().(Compiler); !ok {
 		t.Errorf("GetCompiler")
 	}

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -291,12 +291,11 @@ func (td *TopDocsIMP) GetMatchDocs() []MatchDoc {
 	return slice
 }
 
-func (q *QueryIMP) MakeCompiler(searcher Searcher, boost float32,
-	subordinate bool) (retval Compiler, err error) {
+func (q *QueryIMP) MakeRootCompiler(searcher Searcher) (retval Compiler, err error) {
 	err = clownfish.TrapErr(func() {
 		self := (*C.lucy_Query)(clownfish.Unwrap(q, "q"))
 		searcherCF := (*C.lucy_Searcher)(clownfish.Unwrap(searcher, "searcher"))
-		retvalCF := C.LUCY_Query_Make_Compiler(self, searcherCF, C.float(boost), C.bool(subordinate))
+		retvalCF := C.LUCY_Query_Make_Root_Compiler(self, searcherCF)
 		if retvalCF != nil {
 			retval = clownfish.WRAPAny(unsafe.Pointer(retvalCF)).(Compiler)
 		}

--- a/go/lucy/search.go
+++ b/go/lucy/search.go
@@ -139,7 +139,7 @@ func (s *SearcherIMP) topDocs(query Query, numWanted uint32,
 	err = clownfish.TrapErr(func() {
 		self := (*C.lucy_Searcher)(clownfish.Unwrap(s, "s"))
 		sortSpecC := (*C.lucy_SortSpec)(clownfish.UnwrapNullable(sortSpec))
-		queryC := (*C.lucy_Query)(clownfish.Unwrap(query, "query"))
+		queryC := (*C.cfish_Obj)(clownfish.Unwrap(query, "query"))
 		topDocsC := C.LUCY_Searcher_Top_Docs(self, queryC,
 			C.uint32_t(numWanted), sortSpecC)
 		topDocs = WRAPTopDocs(unsafe.Pointer(topDocsC))

--- a/go/lucy/search_test.go
+++ b/go/lucy/search_test.go
@@ -52,12 +52,12 @@ func checkQueryEquals(t *testing.T, query Query) {
 	}
 }
 
-func checkQueryMakeCompiler(t *testing.T, query Query) {
+func checkQueryMakeRootCompiler(t *testing.T, query Query) {
 	index := createTestIndex("foo", "bar", "baz")
 	searcher, _ := OpenIndexSearcher(index)
-	compiler, err := query.MakeCompiler(searcher, 1.0, false)
+	compiler, err := query.MakeRootCompiler(searcher)
 	if _, ok := compiler.(Compiler); !ok || err != nil {
-		t.Error("MakeCompiler for %v failed: %v", query, err)
+		t.Error("MakeRootCompiler for %v failed: %v", query, err)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestTermQueryMisc(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -118,7 +118,7 @@ func TestPhraseQueryMisc(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -164,7 +164,7 @@ func TestANDQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -177,7 +177,7 @@ func TestORQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -188,7 +188,7 @@ func TestReqOptQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -210,7 +210,7 @@ func TestNOTQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 
@@ -227,7 +227,7 @@ func TestMatchAllQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 }
 
 func TestNOMatchQueryBasics(t *testing.T) {
@@ -235,7 +235,7 @@ func TestNOMatchQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 }
 
 func TestRangeQueryBasics(t *testing.T) {
@@ -243,7 +243,7 @@ func TestRangeQueryBasics(t *testing.T) {
 	checkQuerySerialize(t, query)
 	checkQueryDumpLoad(t, query)
 	checkQueryEquals(t, query)
-	checkQueryMakeCompiler(t, query)
+	checkQueryMakeRootCompiler(t, query)
 	checkQueryToStringHasFoo(t, query)
 }
 

--- a/perl/buildlib/Lucy/Build/Binding/Search.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Search.pm
@@ -574,10 +574,7 @@ sub bind_query {
     
     sub make_compiler {
         my ( $self, %args ) = @_;
-        my $subordinate = delete $args{subordinate};
-        my $compiler = MyCompiler->new( %args, parent => $self );
-        $compiler->normalize unless $subordinate;
-        return $compiler;
+        return MyCompiler->new;
     }
     
     package MyCompiler;
@@ -606,10 +603,19 @@ and MatchAllQuery default to 0.0 instead.
 END_CONSTRUCTOR_POD
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', pod => $constructor, );
+    $pod_spec->add_method(
+        alias  => 'make_compiler',
+        method => 'Make_Compiler',
+    );
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
         class_name => "Lucy::Search::Query",
+    );
+    $binding->exclude_method('Make_Compiler');
+    $binding->bind_method(
+        alias  => 'make_compiler',
+        method => 'Make_Compiler_Compat',
     );
     $binding->set_pod_spec($pod_spec);
 

--- a/perl/buildlib/Lucy/Build/Binding/Search.pm
+++ b/perl/buildlib/Lucy/Build/Binding/Search.pm
@@ -184,12 +184,17 @@ the parent Query.
 END_CONSTRUCTOR_POD
     $pod_spec->set_synopsis($synopsis);
     $pod_spec->add_constructor( alias => 'new', pod => $constructor, );
+    $pod_spec->add_method(
+        method => 'Normalize',
+        alias  => 'normalize',
+    );
 
     my $binding = Clownfish::CFC::Binding::Perl::Class->new(
         parcel     => "Lucy",
         class_name => "Lucy::Search::Compiler",
     );
     $binding->bind_constructor( alias => 'do_new' );
+    $binding->bind_method( alias => '_normalize', method => 'Normalize' );
     $binding->set_pod_spec($pod_spec);
 
     Clownfish::CFC::Binding::Perl::Class->register($binding);

--- a/perl/lib/LucyX/Remote/ClusterSearcher.pm
+++ b/perl/lib/LucyX/Remote/ClusterSearcher.pm
@@ -267,10 +267,7 @@ sub top_docs {
     my $compiler
         = $query->isa("Lucy::Search::Compiler")
         ? $query
-        : $query->make_compiler(
-            searcher => $self,
-            boost    => $query->get_boost,
-          );
+        : $query->make_root_compiler($self);
 
     # Create HitQueue.
     my $hit_q;

--- a/perl/lib/LucyX/Search/Filter.pm
+++ b/perl/lib/LucyX/Search/Filter.pm
@@ -52,11 +52,7 @@ sub DESTROY {
 
 sub make_compiler {
     my ( $self, %args ) = @_;
-    my $subordinate = delete $args{subordinate};
-    my $compiler
-        = LucyX::Search::FilterCompiler->new( %args, parent => $self );
-    $compiler->normalize unless $subordinate;
-    return $compiler;
+    return LucyX::Search::FilterCompiler->new( %args, parent => $self );
 }
 
 sub serialize {

--- a/perl/lib/LucyX/Search/Filter.pm
+++ b/perl/lib/LucyX/Search/Filter.pm
@@ -52,7 +52,7 @@ sub DESTROY {
 
 sub make_compiler {
     my ( $self, %args ) = @_;
-    return LucyX::Search::FilterCompiler->new( %args, parent => $self );
+    return LucyX::Search::FilterCompiler->new( query => $self );
 }
 
 sub serialize {
@@ -169,14 +169,15 @@ BEGIN { our @ISA = qw( Lucy::Search::Compiler ) }
 
 sub new {
     my ( $class, %args ) = @_;
-    $args{similarity} ||= $args{searcher}->get_schema->get_similarity;
-    return $class->SUPER::new(%args);
+    my $self = $class->SUPER::new;
+    $self->{query} = $args{query};
+    return $self;
 }
 
 sub make_matcher {
     my ( $self, %args ) = @_;
     my $seg_reader = $args{reader};
-    my $bits       = $self->get_parent->_bits($seg_reader);
+    my $bits       = $self->{query}->_bits($seg_reader);
     return LucyX::Search::FilterMatcher->new(
         bits    => $bits,
         doc_max => $seg_reader->doc_max,

--- a/perl/sample/PrefixQuery.pm
+++ b/perl/sample/PrefixQuery.pm
@@ -69,10 +69,7 @@ sub to_string {
 
 sub make_compiler {
     my ( $self, %args ) = @_;
-    my $subordinate = delete $args{subordinate};
-    my $compiler = PrefixCompiler->new( %args, parent => $self );
-    $compiler->normalize unless $subordinate;
-    return $compiler;
+    return PrefixCompiler->new( %args, parent => $self );
 }
 
 package PrefixCompiler;

--- a/perl/t/501-termquery.t
+++ b/perl/t/501-termquery.t
@@ -58,10 +58,7 @@ my $different_field = Lucy::Search::TermQuery->new(
 ok( !$term_query->equals($different_term),  "!equals (term)" );
 ok( !$term_query->equals($different_field), "!equals (field)" );
 
-my $term_compiler = $term_query->make_compiler(
-    searcher => $searcher,
-    boost    => $term_query->get_boost,
-);
+my $term_compiler = $term_query->make_root_compiler($searcher);
 $frozen = freeze($term_compiler);
 $thawed = thaw($frozen);
 ok( $term_compiler->equals($thawed), "freeze/thaw compiler" );

--- a/perl/t/502-phrasequery.t
+++ b/perl/t/502-phrasequery.t
@@ -78,10 +78,7 @@ my $thawed = thaw($frozen);
 $hits = $searcher->hits( query => $thawed );
 is( $hits->total_hits, 3, 'freeze/thaw' );
 
-my $phrase_compiler = $phrase_query->make_compiler(
-    searcher => $searcher,
-    boost    => $phrase_query->get_boost,
-);
+my $phrase_compiler = $phrase_query->make_root_compiler($searcher);
 $frozen = freeze($phrase_compiler);
 $thawed = thaw($frozen);
 ok( $phrase_compiler->equals($thawed), "freeze/thaw compiler" );

--- a/perl/t/515-range_query.t
+++ b/perl/t/515-range_query.t
@@ -288,10 +288,7 @@ sub test_range_search {
     my $thawed = thaw($frozen);
     ok( $query->equals($thawed), 'equals' );
 
-    my $compiler = $query->make_compiler(
-        searcher => $searcher,
-        boost    => $query->get_boost,
-    );
+    my $compiler = $query->make_root_compiler($searcher);
     $frozen = nfreeze($compiler);
     $thawed = thaw($frozen);
     ok( $compiler->equals($thawed), "freeze/thaw compiler" );

--- a/perl/t/523-and_query.t
+++ b/perl/t/523-and_query.t
@@ -56,10 +56,7 @@ ok( !$and_query->equals($different_children),
 my $one_child = Lucy::Search::ANDQuery->new( children => [$a_query] );
 ok( !$and_query->equals($one_child), '!equals (too few children)' );
 
-my $and_compiler = $and_query->make_compiler(
-    searcher => $searcher,
-    boost    => $and_query->get_boost,
-);
+my $and_compiler = $and_query->make_root_compiler($searcher);
 isa_ok( $and_compiler, "Lucy::Search::ANDCompiler", "make_compiler" );
 $frozen = freeze($and_compiler);
 $thawed = thaw($frozen);
@@ -71,9 +68,8 @@ my $and_matcher = $and_compiler->make_matcher(
 );
 isa_ok( $and_matcher, "Lucy::Search::ANDMatcher", "make_matcher" );
 
-my $term_matcher = $one_child->make_compiler(
-    searcher => $searcher,
-    boost    => $one_child->get_boost,
+my $term_matcher = $one_child->make_root_compiler(
+    $searcher,
 )->make_matcher( reader => $reader, need_score => 0 );
 isa_ok( $term_matcher, "Lucy::Search::TermMatcher",
     "make_matcher compiles to child's Matcher if there's only one child" );
@@ -83,9 +79,8 @@ my $hopeless_query = Lucy::Search::TermQuery->new(
     term  => 'nein',
 );
 $and_query->add_child($hopeless_query);
-my $nope = $and_query->make_compiler(
-    searcher => $searcher,
-    boost    => $and_query->get_boost,
+my $nope = $and_query->make_root_compiler(
+    $searcher,
 )->make_matcher( reader => $reader, need_score => 0 );
 ok( !defined $nope,
     "If matcher wouldn't return any docs, make_matcher returns undef" );

--- a/perl/t/524-poly_query.t
+++ b/perl/t/524-poly_query.t
@@ -52,10 +52,7 @@ for my $conjunction (qw( AND OR )) {
     my $one_child = $class->new( children => [$a_query] );
     ok( !$polyquery->equals($one_child), '!equals (too few children)' );
 
-    my $compiler = $polyquery->make_compiler(
-        searcher => $searcher,
-        boost    => $polyquery->get_boost,
-    );
+    my $compiler = $polyquery->make_root_compiler($searcher);
     isa_ok( $compiler, "Lucy::Search::${conjunction}Compiler",
         "make_compiler" );
     $frozen = freeze($compiler);
@@ -70,9 +67,8 @@ for my $conjunction (qw( AND OR )) {
         : 'Lucy::Search::ORScorer';
     isa_ok( $matcher, $wanted_class, "make_matcher with need_score" );
 
-    my $term_matcher = $one_child->make_compiler(
-        searcher => $searcher,
-        boost    => $one_child->get_boost,
+    my $term_matcher = $one_child->make_root_compiler(
+        $searcher,
     )->make_matcher( reader => $reader, need_score => 0 );
     isa_ok( $term_matcher, "Lucy::Search::TermMatcher",
         "make_matcher compiles to child's Matcher if there's only one child"
@@ -88,9 +84,8 @@ for my $conjunction (qw( AND OR )) {
     );
     $polyquery
         = $class->new( children => [ $hopeless_query, $doomed_query ] );
-    my $nope = $polyquery->make_compiler(
-        searcher => $searcher,
-        boost    => $polyquery->get_boost,
+    my $nope = $polyquery->make_root_compiler(
+        $searcher,
     )->make_matcher( reader => $reader, need_score => 0 );
     ok( !defined $nope,
         "If Matcher wouldn't return any docs, make_matcher returns undef" );

--- a/perl/t/525-match_all_query.t
+++ b/perl/t/525-match_all_query.t
@@ -52,10 +52,7 @@ ok( $match_all_query->equals($thawed), "equals" );
 $thawed->set_boost(10);
 ok( !$match_all_query->equals($thawed), '!equals (boost)' );
 
-my $compiler = $match_all_query->make_compiler(
-    searcher => $searcher,
-    boost    => $match_all_query->get_boost,
-);
+my $compiler = $match_all_query->make_root_compiler($searcher);
 $frozen = freeze($compiler);
 $thawed = thaw($frozen);
 ok( $thawed->equals($compiler), "freeze/thaw compiler" );

--- a/perl/t/526-not_query.t
+++ b/perl/t/526-not_query.t
@@ -60,10 +60,7 @@ ok( !$not_b_query->equals($thawed), '!equals (boost)' );
 ok( !$not_b_query->equals($not_c_query),
     "!equals (different negated query)" );
 
-my $compiler = $not_b_query->make_compiler(
-    searcher => $searcher,
-    boost    => $not_b_query->get_boost,
-);
+my $compiler = $not_b_query->make_root_compiler($searcher);
 $frozen = freeze($compiler);
 $thawed = thaw($frozen);
 ok( $thawed->equals($compiler), 'freeze/thaw compiler' );

--- a/perl/t/527-req_opt_query.t
+++ b/perl/t/527-req_opt_query.t
@@ -44,10 +44,7 @@ my $req_opt_query = Lucy::Search::RequiredOptionalQuery->new(
 );
 is( $req_opt_query->to_string, "(+content:b content:c)", "to_string" );
 
-my $compiler = $req_opt_query->make_compiler(
-    searcher => $searcher,
-    boost    => $req_opt_query->get_boost,
-);
+my $compiler = $req_opt_query->make_root_compiler($searcher);
 my $frozen   = freeze($compiler);
 my $thawed   = thaw($frozen);
 ok( $thawed->equals($compiler), "freeze/thaw compiler" );
@@ -58,9 +55,8 @@ $req_opt_query = Lucy::Search::RequiredOptionalQuery->new(
     required_query => $x_query,
     optional_query => $b_query,
 );
-$matcher = $req_opt_query->make_compiler(
-    searcher => $searcher,
-    boost    => $req_opt_query->get_boost,
+$matcher = $req_opt_query->make_root_compiler(
+    $searcher,
 )->make_matcher( reader => $reader, need_score => 0 );
 ok( !defined($matcher), "if required matcher has no match, return undef" );
 

--- a/perl/t/529-no_match_query.t
+++ b/perl/t/529-no_match_query.t
@@ -36,10 +36,7 @@ ok( $no_match_query->equals($thawed), "equals" );
 $thawed->set_boost(10);
 ok( !$no_match_query->equals($thawed), '!equals (boost)' );
 
-my $compiler = $no_match_query->make_compiler(
-    searcher => $searcher,
-    boost    => $no_match_query->get_boost,
-);
+my $compiler = $no_match_query->make_root_compiler($searcher);
 $frozen = freeze($compiler);
 $thawed = thaw($frozen);
 ok( $compiler->equals($thawed), "freeze/thaw compiler" );

--- a/perl/t/613-proximityquery.t
+++ b/perl/t/613-proximityquery.t
@@ -86,10 +86,7 @@ my $thawed = thaw($frozen);
 $hits = $searcher->hits( query => $thawed );
 is( $hits->total_hits, 4, 'freeze/thaw' );
 
-my $proximity_compiler = $proximity_query->make_compiler(
-    searcher => $searcher,
-    boost    => $proximity_query->get_boost,
-);
+my $proximity_compiler = $proximity_query->make_root_compiler($searcher);
 $frozen = freeze($proximity_compiler);
 $thawed = thaw($frozen);
 ok( $proximity_compiler->equals($thawed), "freeze/thaw compiler" );

--- a/perl/t/binding/303-highlighter.t
+++ b/perl/t/binding/303-highlighter.t
@@ -109,10 +109,7 @@ like(
 );
 
 $q = $searcher->glean_query("foo");
-my $compiler = $q->make_compiler(
-    searcher => $searcher,
-    boost    => $q->get_boost,
-);
+my $compiler = $q->make_root_compiler($searcher);
 $hl = Lucy::Highlight::Highlighter->new(
     searcher => $searcher,
     query    => $compiler,

--- a/perl/t/binding/303-highlighter.t
+++ b/perl/t/binding/303-highlighter.t
@@ -55,7 +55,7 @@ sub highlight {
 
 package main;
 
-use Test::More tests => 6;
+use Test::More tests => 5;
 use Lucy::Test;
 
 binmode( STDOUT, ":utf8" );
@@ -115,8 +115,6 @@ $hl = Lucy::Highlight::Highlighter->new(
     query    => $compiler,
     field    => 'content',
 );
-is( $$compiler, ${ $hl->get_query },
-    "Highlighter accepts Compiler as Query" );
 is( $$compiler, ${ $hl->get_compiler },
     "Highlighter uses supplied Compiler" );
 

--- a/perl/t/binding/800-stack.t
+++ b/perl/t/binding/800-stack.t
@@ -24,10 +24,7 @@ use base qw( Lucy::Search::Query );
 
 sub make_compiler {
     my ( $self, %args ) = @_;
-    my $subordinate = delete $args{subordinate};
-    my $compiler = MyCompiler->new( %args, parent => $self );
-    $compiler->normalize unless $subordinate;
-    return $compiler;
+    return MyCompiler->new( %args, parent => $self );
 }
 
 package MyCompiler;
@@ -47,10 +44,7 @@ for ( 1 .. 50 ) {
     $q = Lucy::Search::ORQuery->new( children => \@kids );
 }
 my $searcher = MockSearcher->new( schema => Lucy::Plan::Schema->new );
-my $compiler = $q->make_compiler(
-    searcher => $searcher,
-    boost    => $q->get_boost,
-);
+my $compiler = $q->make_root_compiler($searcher);
 
 pass("Made it through deep recursion with multiple stack reallocations");
 

--- a/perl/t/binding/800-stack.t
+++ b/perl/t/binding/800-stack.t
@@ -23,8 +23,7 @@ package MyQuery;
 use base qw( Lucy::Search::Query );
 
 sub make_compiler {
-    my ( $self, %args ) = @_;
-    return MyCompiler->new( %args, parent => $self );
+    return MyCompiler->new;
 }
 
 package MyCompiler;

--- a/perl/t/binding/802-old_query_api.t
+++ b/perl/t/binding/802-old_query_api.t
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+package MockSearcher;
+use base qw( Lucy::Search::Searcher );
+
+sub doc_max  { 100 }
+sub doc_freq {   1 }
+
+package MyQuery;
+use base qw( Lucy::Search::Query );
+
+our $subordinate_arg;
+
+sub make_compiler {
+    my ( $self, %args ) = @_;
+    $subordinate_arg = delete($args{subordinate});
+    return MyCompiler->new( %args, parent => $self );
+}
+
+package MyCompiler;
+use base qw( Lucy::Search::Compiler );
+
+our $similarity_arg;
+
+sub new {
+    my ( $self, %args ) = @_;
+    return $self->SUPER::new(%args);
+}
+
+sub _normalize {
+    my ( $self, $sim ) = @_;
+    $similarity_arg = $sim;
+}
+
+package QueryWithoutMakeCompiler;
+use base qw( Lucy::Search::Query );
+
+package main;
+use Test::More tests => 8;
+
+my $schema   = Lucy::Plan::Schema->new;
+my $sim      = $schema->get_similarity;
+my $searcher = MockSearcher->new( schema => $schema );
+my $query;
+my $compiler;
+
+$query = MyQuery->new;
+$query->set_boost(123.0);
+$compiler = $query->make_root_compiler($searcher);
+ok( $MyQuery::subordinate_arg, "make_compiler receives true subordinate arg" );
+
+is( $compiler->get_boost, 123.0, "get_boost" );
+is( $compiler->get_weight, 123.0, "get_weight" );
+is( ${ $compiler->get_parent }, $$query, "get_parent" );
+is( ${ $compiler->get_similarity }, $$sim, "get_similarity" );
+
+$MyCompiler::similarity_arg = undef;
+$compiler->normalize;
+is( $$MyCompiler::similarity_arg, $$sim, "normalize without sim" );
+
+eval {
+    QueryWithoutMakeCompiler->new->make_root_compiler($searcher);
+};
+like( $@, qr('Make_Compiler' not defined by QueryWithoutMakeCompiler),
+      "Subclassing Query without overriding make_compiler throws" );
+
+$query = Lucy::Search::TermQuery->new( field => 'content', term => 'foo' );
+$compiler = $query->make_compiler(
+    searcher => $searcher,
+    boost    => 64.0,
+);
+# normalized_weight == idf == 1 + log(100 / (1 + 1))
+ok( $compiler->get_weight > 1, "make_compiler normalizes Compiler" );
+

--- a/perl/t/core/613-proximity_query.t
+++ b/perl/t/core/613-proximity_query.t
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+use strict;
+use warnings;
+
+use Lucy::Test;
+my $success = Lucy::Test::run_tests("LucyX::Test::Search::TestProximityQuery");
+
+exit($success ? 0 : 1);
+

--- a/test/Lucy/Test.c
+++ b/test/Lucy/Test.c
@@ -89,6 +89,7 @@
 #include "Lucy/Test/Util/TestPriorityQueue.h"
 #include "Lucy/Test/Util/TestSortExternal.h"
 #include "Lucy/Test/Util/TestStringHelper.h"
+#include "LucyX/Test/Search/TestProximityQuery.h"
 
 TestSuite*
 Test_create_test_suite() {
@@ -160,6 +161,7 @@ Test_create_test_suite() {
     TestSuite_Add_Batch(suite, (TestBatch*)TestNoMatchQuery_new());
     TestSuite_Add_Batch(suite, (TestBatch*)TestSeriesMatcher_new());
     TestSuite_Add_Batch(suite, (TestBatch*)TestORQuery_new());
+    TestSuite_Add_Batch(suite, (TestBatch*)TestProximityQuery_new());
     TestSuite_Add_Batch(suite, (TestBatch*)TestQPLogic_new());
     TestSuite_Add_Batch(suite, (TestBatch*)TestQPSyntax_new());
 

--- a/test/Lucy/Test/Search/MockSearcher.c
+++ b/test/Lucy/Test/Search/MockSearcher.c
@@ -1,0 +1,50 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define TESTLUCY_USE_SHORT_NAMES
+#include "Lucy/Util/ToolSet.h"
+
+#include "Lucy/Test/Search/MockSearcher.h"
+#include "Lucy/Test/TestSchema.h"
+
+MockSearcher*
+MockSearcher_new() {
+    MockSearcher *self = (MockSearcher*)Class_Make_Obj(MOCKSEARCHER);
+    return MockSearcher_init(self);
+}
+
+MockSearcher*
+MockSearcher_init(MockSearcher *self) {
+    Schema *schema = (Schema*)TestSchema_new(false);
+    Searcher_init((Searcher*)self, schema);
+    DECREF(schema);
+    return self;
+}
+
+int32_t
+MockSearcher_Doc_Max_IMP(MockSearcher *self) {
+    UNUSED_VAR(self);
+    return 2500;
+}
+
+uint32_t
+MockSearcher_Doc_Freq_IMP(MockSearcher *self, String *field, Obj *term) {
+    UNUSED_VAR(self);
+    UNUSED_VAR(field);
+    UNUSED_VAR(term);
+    return 10;
+}
+

--- a/test/Lucy/Test/Search/MockSearcher.cfh
+++ b/test/Lucy/Test/Search/MockSearcher.cfh
@@ -1,0 +1,34 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+parcel TestLucy;
+
+class Lucy::Test::Search::MockSearcher inherits Lucy::Search::Searcher {
+
+    public inert incremented MockSearcher*
+    new();
+
+    public inert MockSearcher*
+    init(MockSearcher *self);
+
+    public int32_t
+    Doc_Max(MockSearcher *self);
+
+    public uint32_t
+    Doc_Freq(MockSearcher *self, String *field, Obj *term);
+}
+
+

--- a/test/Lucy/Test/Search/TestMatchAllQuery.c
+++ b/test/Lucy/Test/Search/TestMatchAllQuery.c
@@ -47,11 +47,17 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    TestUtils_test_freeze_thaw(runner, (Obj*)MatchAllCompiler_new(38.0f),
+                               "compiler");
+}
 
 void
 TestMatchAllQuery_Run_IMP(TestMatchAllQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 2);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 3);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/Search/TestNOTQuery.c
+++ b/test/Lucy/Test/Search/TestNOTQuery.c
@@ -22,9 +22,11 @@
 #include "Clownfish/TestHarness/TestBatchRunner.h"
 #include "Lucy/Test.h"
 #include "Lucy/Test/TestUtils.h"
+#include "Lucy/Test/Search/MockSearcher.h"
 #include "Lucy/Test/Search/TestNOTQuery.h"
 #include "Lucy/Search/NOTQuery.h"
 #include "Lucy/Search/LeafQuery.h"
+#include "Lucy/Search/TermQuery.h"
 #include "Lucy/Util/Freezer.h"
 
 TestNOTQuery*
@@ -61,10 +63,22 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    NOTQuery *query = TestUtils_make_not_query(
+        (Query*)TermQuery_new(SSTR_WRAP_C("content"), (Obj*)SSTR_WRAP_C("a")));
+    Searcher *searcher = (Searcher*)MockSearcher_new();
+    NOTCompiler *compiler = NOTCompiler_new(query, searcher, 921.0f);
+    TestUtils_test_freeze_thaw(runner, (Obj*)compiler, "compiler");
+    DECREF(searcher);
+    DECREF(query);
+}
+
 void
 TestNOTQuery_Run_IMP(TestNOTQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 4);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 5);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/Search/TestNoMatchQuery.c
+++ b/test/Lucy/Test/Search/TestNoMatchQuery.c
@@ -47,11 +47,17 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    TestUtils_test_freeze_thaw(runner, (Obj*)NoMatchCompiler_new(),
+                               "compiler");
+}
 
 void
 TestNoMatchQuery_Run_IMP(TestNoMatchQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 2);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 3);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/Search/TestPolySearcher.c
+++ b/test/Lucy/Test/Search/TestPolySearcher.c
@@ -111,7 +111,7 @@ test_poly_searcher(TestBatchRunner *runner) {
     Collector *collector = (Collector*)BitColl_new(bit_vec);
     Query *query = PolySearcher_Glean_Query(poly_searcher,
                                             (Obj*)SSTR_WRAP_C("b"));
-    PolySearcher_Collect(poly_searcher, query, collector);
+    PolySearcher_Collect(poly_searcher, (Obj*)query, collector);
     TEST_INT_EQ(runner, BitVec_Next_Hit(bit_vec, 0),  2, "Collect doc 1");
     TEST_INT_EQ(runner, BitVec_Next_Hit(bit_vec, 3),  4, "Collect doc 2");
     TEST_INT_EQ(runner, BitVec_Next_Hit(bit_vec, 5), -1, "Collect end");

--- a/test/Lucy/Test/Search/TestRangeQuery.c
+++ b/test/Lucy/Test/Search/TestRangeQuery.c
@@ -65,11 +65,20 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    RangeQuery *query
+        = TestUtils_make_range_query("content", "a", "b", true, true);
+    RangeCompiler *compiler = RangeCompiler_new(query, 672.0f);
+    TestUtils_test_freeze_thaw(runner, (Obj*)compiler, "compiler");
+    DECREF(query);
+}
 
 void
 TestRangeQuery_Run_IMP(TestRangeQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 5);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 6);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/Search/TestReqOptQuery.c
+++ b/test/Lucy/Test/Search/TestReqOptQuery.c
@@ -22,9 +22,11 @@
 #include "Clownfish/TestHarness/TestBatchRunner.h"
 #include "Lucy/Test.h"
 #include "Lucy/Test/TestUtils.h"
+#include "Lucy/Test/Search/MockSearcher.h"
 #include "Lucy/Test/Search/TestReqOptQuery.h"
 #include "Lucy/Search/RequiredOptionalQuery.h"
 #include "Lucy/Search/LeafQuery.h"
+#include "Lucy/Search/TermQuery.h"
 #include "Lucy/Util/Freezer.h"
 
 TestReqOptQuery*
@@ -64,10 +66,27 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    String *field = SSTR_WRAP_C("content");
+    TermQuery *req = TermQuery_new(field, (Obj*)SSTR_WRAP_C("a"));
+    TermQuery *opt = TermQuery_new(field, (Obj*)SSTR_WRAP_C("b"));
+    RequiredOptionalQuery *query = ReqOptQuery_new((Query*)req, (Query*)opt);
+    Searcher *searcher = (Searcher*)MockSearcher_new();
+    RequiredOptionalCompiler *compiler
+        = ReqOptCompiler_new(query, searcher, 921.0f);
+    TestUtils_test_freeze_thaw(runner, (Obj*)compiler, "compiler");
+    DECREF(searcher);
+    DECREF(query);
+    DECREF(opt);
+    DECREF(req);
+}
+
 void
 TestReqOptQuery_Run_IMP(TestReqOptQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 4);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 5);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/Search/TestTermQuery.c
+++ b/test/Lucy/Test/Search/TestTermQuery.c
@@ -21,6 +21,7 @@
 
 #include "Clownfish/TestHarness/TestBatchRunner.h"
 #include "Lucy/Test.h"
+#include "Lucy/Test/Search/MockSearcher.h"
 #include "Lucy/Test/Search/TestTermQuery.h"
 #include "Lucy/Test/TestUtils.h"
 #include "Lucy/Search/TermQuery.h"
@@ -57,10 +58,21 @@ test_Dump_Load_and_Equals(TestBatchRunner *runner) {
     DECREF(clone);
 }
 
+static void
+test_freeze_thaw_compiler(TestBatchRunner *runner) {
+    TermQuery *query = TestUtils_make_term_query("content", "foo");
+    Searcher *searcher = (Searcher*)MockSearcher_new();
+    TermCompiler *compiler = TermCompiler_new(query, searcher, 433.0f);
+    TestUtils_test_freeze_thaw(runner, (Obj*)compiler, "compiler");
+    DECREF(searcher);
+    DECREF(query);
+}
+
 void
 TestTermQuery_Run_IMP(TestTermQuery *self, TestBatchRunner *runner) {
-    TestBatchRunner_Plan(runner, (TestBatch*)self, 4);
+    TestBatchRunner_Plan(runner, (TestBatch*)self, 5);
     test_Dump_Load_and_Equals(runner);
+    test_freeze_thaw_compiler(runner);
 }
 
 

--- a/test/Lucy/Test/TestUtils.c
+++ b/test/Lucy/Test/TestUtils.c
@@ -229,3 +229,20 @@ TestUtils_modules_folder() {
     return NULL;
 }
 
+void
+TestUtils_test_freeze_thaw(TestBatchRunner *runner, Obj *obj,
+                           const char *msg) {
+    RAMFile *file = RAMFile_new(NULL, false);
+    OutStream *outstream = OutStream_open((Obj*)file);
+    Freezer_freeze(obj, outstream);
+    OutStream_Close(outstream);
+    InStream *instream = InStream_open((Obj*)file);
+    Obj *thawed = Freezer_thaw(instream);
+    TEST_TRUE(runner, Obj_Equals(obj, thawed), "freeze/thaw %s", msg);
+    DECREF(thawed);
+    DECREF(instream);
+    DECREF(outstream);
+    DECREF(file);
+    DECREF(obj);
+}
+

--- a/test/Lucy/Test/TestUtils.cfh
+++ b/test/Lucy/Test/TestUtils.cfh
@@ -82,6 +82,12 @@ inert class Lucy::Test::TestUtils  {
      */
     inert incremented nullable FSFolder*
     modules_folder();
+
+    /** Test whether a freeze/thaw round trip yields an equal object.
+     */
+    inert void
+    test_freeze_thaw(TestBatchRunner *runner, decremented Obj *obj,
+                     const char *msg);
 }
 
 __C__

--- a/test/LucyX/Test/Search/TestProximityQuery.cfh
+++ b/test/LucyX/Test/Search/TestProximityQuery.cfh
@@ -1,0 +1,29 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+parcel TestLucy;
+
+class LucyX::Test::Search::TestProximityQuery
+    inherits Clownfish::TestHarness::TestBatch {
+
+    inert incremented TestProximityQuery*
+    new();
+
+    void
+    Run(TestProximityQuery *self, TestBatchRunner *runner);
+}
+
+


### PR DESCRIPTION
Remove all instance variables from the Compiler base class.

- Make Compiler inherit from Obj instead of Query.
- Use per-subclass ivar for boost if needed.
- Copy some relevant ivars from the respective Query.
- Fetch Similarity from DataReader's schema.
